### PR TITLE
Bundled deps 2025-05-12

### DIFF
--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,6 +1,6 @@
 {
     "name": "chaos",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "description": "An asset bundle for developers",
     "minimum_teraslice_version": "2.0.0"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,7 +1,7 @@
 {
     "name": "chaos",
     "displayName": "Asset",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "private": true,
     "description": "An asset bundle for developers",
     "repository": {
@@ -21,13 +21,13 @@
         "test": "yarn --cwd ../ test"
     },
     "dependencies": {
-        "@terascope/data-mate": "~1.8.0",
-        "@terascope/job-components": "~1.10.0",
-        "@terascope/teraslice-state-storage": "~1.9.0",
-        "@terascope/utils": "~1.8.0",
+        "@terascope/data-mate": "~1.8.1",
+        "@terascope/job-components": "~1.10.1",
+        "@terascope/teraslice-state-storage": "~1.9.1",
+        "@terascope/utils": "~1.8.1",
         "@types/express": "~5.0.1",
         "express": "~5.1.0",
-        "ts-transforms": "~1.8.0",
+        "ts-transforms": "~1.8.1",
         "tslib": "~2.8.1"
     },
     "engines": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "chaos-assets-bundle",
     "displayName": "Chaos Assets Bundle",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "private": true,
     "description": "An asset bundle for developers",
     "type": "module",
@@ -29,14 +29,14 @@
         "test:watch": "ts-scripts test --watch asset --"
     },
     "devDependencies": {
-        "@terascope/eslint-config": "~1.1.13",
-        "@terascope/job-components": "~1.10.0",
-        "@terascope/scripts": "~1.16.0",
+        "@terascope/eslint-config": "~1.1.14",
+        "@terascope/job-components": "~1.10.1",
+        "@terascope/scripts": "~1.16.1",
         "@types/express": "~5.0.1",
         "@types/fs-extra": "~11.0.4",
         "@types/jest": "~29.5.14",
         "@types/json2csv": "~5.0.7",
-        "@types/node": "~22.15.3",
+        "@types/node": "~22.15.17",
         "@types/node-gzip": "~1.1.3",
         "@types/semver": "~7.7.0",
         "@types/timsort": "~0.3.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -418,15 +418,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/compat@npm:~1.2.8":
-  version: 1.2.8
-  resolution: "@eslint/compat@npm:1.2.8"
+"@eslint/compat@npm:~1.2.9":
+  version: 1.2.9
+  resolution: "@eslint/compat@npm:1.2.9"
   peerDependencies:
     eslint: ^9.10.0
   peerDependenciesMeta:
     eslint:
       optional: true
-  checksum: 10c0/1e004c6917220ff1731fdc562ada9ddcbcecc6f3ba2e4b0433fb6d8eddf2a443e009f1f9796b78128b78a0a588c723b78021319055ac6e5dda55c0ace346496b
+  checksum: 10c0/e912058f1e3847a1eec654c0c040467b676bd48171e915c730c7215f57cf5f4db8508c4a431ccb470f4a000d94559b41c4fe8de3d71f23eb8ae7acf4959e1c06
   languageName: node
   linkType: hard
 
@@ -441,19 +441,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/config-helpers@npm:^0.2.0, @eslint/config-helpers@npm:^0.2.1":
+"@eslint/config-helpers@npm:^0.2.1":
   version: 0.2.1
   resolution: "@eslint/config-helpers@npm:0.2.1"
   checksum: 10c0/3e829a78b0bb4f7c44384ba1df3986e5de24b7f440ad5c6bb3cfc366ded773a869ca9ee8d212b5a563ae94596c5940dea6fd2ea1ee53a84c6241ac953dcb8bb7
-  languageName: node
-  linkType: hard
-
-"@eslint/core@npm:^0.12.0":
-  version: 0.12.0
-  resolution: "@eslint/core@npm:0.12.0"
-  dependencies:
-    "@types/json-schema": "npm:^7.0.15"
-  checksum: 10c0/d032af81195bb28dd800c2b9617548c6c2a09b9490da3c5537fd2a1201501666d06492278bb92cfccac1f7ac249e58601dd87f813ec0d6a423ef0880434fa0c3
   languageName: node
   linkType: hard
 
@@ -483,14 +474,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/js@npm:9.24.0, @eslint/js@npm:~9.24.0":
-  version: 9.24.0
-  resolution: "@eslint/js@npm:9.24.0"
-  checksum: 10c0/efe22e29469e4140ac3e2916be8143b1bcfd1084a6edf692b7a58a3e54949d53c67f7f979bc0a811db134d9cc1e7bff8aa71ef1376b47eecd7e226b71206bb36
-  languageName: node
-  linkType: hard
-
-"@eslint/js@npm:9.26.0":
+"@eslint/js@npm:9.26.0, @eslint/js@npm:~9.26.0":
   version: 9.26.0
   resolution: "@eslint/js@npm:9.26.0"
   checksum: 10c0/89fa45b7ff7f3c2589ea1f04a31b4f6d41ad85ecac98e519195e8b3a908b103c892ac19c4aec0629cfeccefd9e5b63c2f1269183d63016e7de722b97a085dcf4
@@ -504,7 +488,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/plugin-kit@npm:^0.2.7, @eslint/plugin-kit@npm:^0.2.8":
+"@eslint/plugin-kit@npm:^0.2.8":
   version: 0.2.8
   resolution: "@eslint/plugin-kit@npm:0.2.8"
   dependencies:
@@ -1171,15 +1155,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@terascope/data-mate@npm:~1.8.0":
-  version: 1.8.0
-  resolution: "@terascope/data-mate@npm:1.8.0"
+"@terascope/data-mate@npm:~1.8.1":
+  version: 1.8.1
+  resolution: "@terascope/data-mate@npm:1.8.1"
   dependencies:
-    "@terascope/data-types": "npm:~1.8.0"
+    "@terascope/data-types": "npm:~1.8.1"
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.8.0"
+    "@terascope/utils": "npm:~1.8.1"
     "@types/validator": "npm:~13.12.2"
-    awesome-phonenumber: "npm:~7.4.0"
+    awesome-phonenumber: "npm:~7.5.0"
     date-fns: "npm:~4.1.0"
     ip-bigint: "npm:~8.2.1"
     ip6addr: "npm:~0.2.5"
@@ -1190,47 +1174,47 @@ __metadata:
     uuid: "npm:~11.1.0"
     valid-url: "npm:~1.0.9"
     validator: "npm:~13.12.0"
-    xlucene-parser: "npm:~1.8.0"
-  checksum: 10c0/b2688e7b158f2c010dc79d027cf39970e3a7b209441ded2f2defbd21eda29a732608f3639dac8e2aeb69e0a4b6b5b1be5328c491ab3222f590b0b85572f2de8c
+    xlucene-parser: "npm:~1.8.1"
+  checksum: 10c0/e4640551e8b5c18fd9497a57659d0a34134a2d20e0a52667886ebb19bdb3b508c2d3f11de216c734c46fea1d734d64f06465e1d43951a9f14c3780f4151c1e3b
   languageName: node
   linkType: hard
 
-"@terascope/data-types@npm:~1.8.0":
-  version: 1.8.0
-  resolution: "@terascope/data-types@npm:1.8.0"
+"@terascope/data-types@npm:~1.8.1":
+  version: 1.8.1
+  resolution: "@terascope/data-types@npm:1.8.1"
   dependencies:
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.8.0"
+    "@terascope/utils": "npm:~1.8.1"
     graphql: "npm:~16.10.0"
     yargs: "npm:~17.7.2"
   bin:
     data-types: ./bin/data-types.js
-  checksum: 10c0/5b03af6d5f2449fc022e81c1a2e436dad50c98303945637eaccf56bdffbee4cd4bba0815e560069d2431a5a01427c41e0dd783468df95c3dfdd27d5b63bf1770
+  checksum: 10c0/855ff77dda9c34f0f18c78b3cc694dae2126f0894c0375154a788ee917ef369cf120800abf294f271354e339319ca09eea3fad882b1795b1e2cab04990221ec6
   languageName: node
   linkType: hard
 
-"@terascope/elasticsearch-api@npm:~4.9.0":
-  version: 4.9.0
-  resolution: "@terascope/elasticsearch-api@npm:4.9.0"
+"@terascope/elasticsearch-api@npm:~4.9.1":
+  version: 4.9.1
+  resolution: "@terascope/elasticsearch-api@npm:4.9.1"
   dependencies:
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.8.0"
+    "@terascope/utils": "npm:~1.8.1"
     bluebird: "npm:~3.7.2"
     setimmediate: "npm:~1.0.5"
-  checksum: 10c0/d8a6ce64885da6e469d542f1a7ac701c056b2d7726808d6c292be9ab8f1efcd5f18ee5f5bb01e2db27505b5ef67768010952aa055fa3b13a31a1697ff8ea6110
+  checksum: 10c0/3d0836b57c67cf53d9f3ae46f5f74e335432ca35c2eb31e0e1888da8e7717cd91a6493ebdfe31f6250d73a5ac2418c0a9564e3cfcee3df2838e69b47ad4f04c6
   languageName: node
   linkType: hard
 
-"@terascope/eslint-config@npm:~1.1.13":
-  version: 1.1.13
-  resolution: "@terascope/eslint-config@npm:1.1.13"
+"@terascope/eslint-config@npm:~1.1.14":
+  version: 1.1.14
+  resolution: "@terascope/eslint-config@npm:1.1.14"
   dependencies:
-    "@eslint/compat": "npm:~1.2.8"
-    "@eslint/js": "npm:~9.24.0"
+    "@eslint/compat": "npm:~1.2.9"
+    "@eslint/js": "npm:~9.26.0"
     "@stylistic/eslint-plugin": "npm:~4.2.0"
-    "@typescript-eslint/eslint-plugin": "npm:~8.29.1"
-    "@typescript-eslint/parser": "npm:~8.29.1"
-    eslint: "npm:~9.24.0"
+    "@typescript-eslint/eslint-plugin": "npm:~8.31.1"
+    "@typescript-eslint/parser": "npm:~8.31.1"
+    eslint: "npm:~9.26.0"
     eslint-plugin-import: "npm:~2.31.0"
     eslint-plugin-jest: "npm:~28.11.0"
     eslint-plugin-jest-dom: "npm:~5.5.0"
@@ -1240,8 +1224,8 @@ __metadata:
     eslint-plugin-testing-library: "npm:~7.1.1"
     globals: "npm:~16.0.0"
     typescript: "npm:~5.8.3"
-    typescript-eslint: "npm:~8.30.1"
-  checksum: 10c0/d82778097a87b0d2f08c00e716f14fbbab939df885d75e4e46293199ac77125729ff82ae80ba79b2ca3d876e195d46921c00e9cac7a3fabb9f2731172d39128a
+    typescript-eslint: "npm:~8.31.1"
+  checksum: 10c0/47965f242c08608a1d6744486141c93162df03ef5b5da4eb7c2cbcf865efaf2633d895e076c95ae4e76ac2606126187b32af244cf4a6244d4d6f609baa99c2fb
   languageName: node
   linkType: hard
 
@@ -1260,12 +1244,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@terascope/job-components@npm:~1.10.0":
-  version: 1.10.0
-  resolution: "@terascope/job-components@npm:1.10.0"
+"@terascope/job-components@npm:~1.10.1":
+  version: 1.10.1
+  resolution: "@terascope/job-components@npm:1.10.1"
   dependencies:
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.8.0"
+    "@terascope/utils": "npm:~1.8.1"
     convict: "npm:~6.2.4"
     convict-format-with-moment: "npm:~6.2.0"
     convict-format-with-validator: "npm:~6.2.0"
@@ -1274,16 +1258,16 @@ __metadata:
     prom-client: "npm:~15.1.3"
     semver: "npm:~7.7.1"
     uuid: "npm:~11.1.0"
-  checksum: 10c0/39100f2552c0ad5e0d2d1cfbcd88ce597278320d63573ea49d556819ceaad5c405fecd0caf4fd6246413c97f67d4e9e572e6da9cefa799d26332141a84757fde
+  checksum: 10c0/71482ca19d8a5b665b2ff18795b1759d612760f58e21b1bb66c85809b5519f94db995e8339c39dbf910877da2f54bbf340bfaf98e98e49d118bd25191c63338f
   languageName: node
   linkType: hard
 
-"@terascope/scripts@npm:~1.16.0":
-  version: 1.16.0
-  resolution: "@terascope/scripts@npm:1.16.0"
+"@terascope/scripts@npm:~1.16.1":
+  version: 1.16.1
+  resolution: "@terascope/scripts@npm:1.16.1"
   dependencies:
     "@kubernetes/client-node": "npm:~1.1.2"
-    "@terascope/utils": "npm:~1.8.0"
+    "@terascope/utils": "npm:~1.8.1"
     execa: "npm:~9.5.2"
     fs-extra: "npm:~11.3.0"
     globby: "npm:~14.1.0"
@@ -1300,8 +1284,8 @@ __metadata:
     signale: "npm:~1.4.0"
     sort-package-json: "npm:~2.15.1"
     toposort: "npm:~2.0.2"
-    typedoc: "npm:~0.28.2"
-    typedoc-plugin-markdown: "npm:~4.6.2"
+    typedoc: "npm:~0.28.4"
+    typedoc-plugin-markdown: "npm:~4.6.3"
     yaml: "npm:^2.7.1"
     yargs: "npm:~17.7.2"
   peerDependencies:
@@ -1311,17 +1295,17 @@ __metadata:
       optional: true
   bin:
     ts-scripts: ./bin/ts-scripts.js
-  checksum: 10c0/3cdad6c14749ff61c77eda15798cc54191c4a733c9ae566d312fe331de86a31ac7db3b6ffc81c9b617770417d900eb13543f567dbe4e765ec8ec78b607247124
+  checksum: 10c0/a0fcae6ea0746bfe60047405348288f73ac84430648b573921da504fae7b9250a01850faa2971287bf15a52c3807135b20de5fde0f17441b00963ee259839d0d
   languageName: node
   linkType: hard
 
-"@terascope/teraslice-state-storage@npm:~1.9.0":
-  version: 1.9.0
-  resolution: "@terascope/teraslice-state-storage@npm:1.9.0"
+"@terascope/teraslice-state-storage@npm:~1.9.1":
+  version: 1.9.1
+  resolution: "@terascope/teraslice-state-storage@npm:1.9.1"
   dependencies:
-    "@terascope/elasticsearch-api": "npm:~4.9.0"
-    "@terascope/utils": "npm:~1.8.0"
-  checksum: 10c0/420d1490341f0eb012765979b864d706a9863ba19627566f0c7857e1d6f779c4b5014ddfb2e23ced3547b8bf559c3a2dd91bdec13fcf7ec816b72c374a0e8e62
+    "@terascope/elasticsearch-api": "npm:~4.9.1"
+    "@terascope/utils": "npm:~1.8.1"
+  checksum: 10c0/89d5a467ae0bc3a036146e647393ee68e21d9e340f2798458f239482d539f52d6921850fe8eb3cb4148a72b538c45bd58ee75fe0e87754ab455346c887e37c0a
   languageName: node
   linkType: hard
 
@@ -1334,9 +1318,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@terascope/utils@npm:~1.8.0":
-  version: 1.8.0
-  resolution: "@terascope/utils@npm:1.8.0"
+"@terascope/utils@npm:~1.8.1":
+  version: 1.8.1
+  resolution: "@terascope/utils@npm:1.8.1"
   dependencies:
     "@chainsafe/is-ip": "npm:~2.1.0"
     "@terascope/types": "npm:~1.4.1"
@@ -1354,7 +1338,7 @@ __metadata:
     "@turf/line-to-polygon": "npm:~7.2.0"
     "@types/lodash-es": "npm:~4.17.12"
     "@types/validator": "npm:~13.12.2"
-    awesome-phonenumber: "npm:~7.4.0"
+    awesome-phonenumber: "npm:~7.5.0"
     date-fns: "npm:~4.1.0"
     date-fns-tz: "npm:~3.2.0"
     datemath-parser: "npm:~1.0.6"
@@ -1374,7 +1358,7 @@ __metadata:
     p-map: "npm:~7.0.3"
     shallow-clone: "npm:~3.0.1"
     validator: "npm:~13.12.0"
-  checksum: 10c0/12f59ea11f4c3ac16a84f771944f22b9650d4586d81f25efab4573bdbece848267828d9d69bd7694bf1a7320b978309d6932f1db3fec9a474bd8e5217174e77c
+  checksum: 10c0/6d0d671b01a215fefb6750ebb5a8311dee0275c265cd210fa54175d9da4161ed21c62507e997aaab504eb11f9050c13777e240a6f09fc3ecebae225e2300bcb1
   languageName: node
   linkType: hard
 
@@ -1899,12 +1883,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:~22.15.3":
-  version: 22.15.3
-  resolution: "@types/node@npm:22.15.3"
+"@types/node@npm:~22.15.17":
+  version: 22.15.17
+  resolution: "@types/node@npm:22.15.17"
   dependencies:
     undici-types: "npm:~6.21.0"
-  checksum: 10c0/2879f012d1aeba0bfdb5fed80d165f4f2cb3d1f2e1f98a24b18d4a211b4ace7d64bf2622784c78355982ffc1081ba79d0934efc2fb8353913e5871a63609661f
+  checksum: 10c0/fb92aa10b628683c5b965749f955bc2322485ecb0ea6c2f4cae5f2c7537a16834607e67083a9e9281faaae8d7dee9ada8d6a5c0de9a52c17d82912ef00c0fdd4
   languageName: node
   linkType: hard
 
@@ -2031,15 +2015,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/eslint-plugin@npm:8.30.1":
-  version: 8.30.1
-  resolution: "@typescript-eslint/eslint-plugin@npm:8.30.1"
+"@typescript-eslint/eslint-plugin@npm:8.31.1, @typescript-eslint/eslint-plugin@npm:~8.31.1":
+  version: 8.31.1
+  resolution: "@typescript-eslint/eslint-plugin@npm:8.31.1"
   dependencies:
     "@eslint-community/regexpp": "npm:^4.10.0"
-    "@typescript-eslint/scope-manager": "npm:8.30.1"
-    "@typescript-eslint/type-utils": "npm:8.30.1"
-    "@typescript-eslint/utils": "npm:8.30.1"
-    "@typescript-eslint/visitor-keys": "npm:8.30.1"
+    "@typescript-eslint/scope-manager": "npm:8.31.1"
+    "@typescript-eslint/type-utils": "npm:8.31.1"
+    "@typescript-eslint/utils": "npm:8.31.1"
+    "@typescript-eslint/visitor-keys": "npm:8.31.1"
     graphemer: "npm:^1.4.0"
     ignore: "npm:^5.3.1"
     natural-compare: "npm:^1.4.0"
@@ -2048,60 +2032,23 @@ __metadata:
     "@typescript-eslint/parser": ^8.0.0 || ^8.0.0-alpha.0
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <5.9.0"
-  checksum: 10c0/e34e067c977a20fe927a30e5ffd5402b03eb12d1c9dc932e7c4a772e78fda9e34708fa2d12ace34bad2c51ecaf5b8cfaa4b372c0c5550fe06587b721f6eae57b
+  checksum: 10c0/9d805ab413a666fd2eefb16f257fbf3cea7278ccaf0db30ceb686dfe696e4f40b3aa7c336261c7f0a39a51a7c32a4f08d3d4f16bba0e764ac12c93ae94d82896
   languageName: node
   linkType: hard
 
-"@typescript-eslint/eslint-plugin@npm:~8.29.1":
-  version: 8.29.1
-  resolution: "@typescript-eslint/eslint-plugin@npm:8.29.1"
+"@typescript-eslint/parser@npm:8.31.1, @typescript-eslint/parser@npm:~8.31.1":
+  version: 8.31.1
+  resolution: "@typescript-eslint/parser@npm:8.31.1"
   dependencies:
-    "@eslint-community/regexpp": "npm:^4.10.0"
-    "@typescript-eslint/scope-manager": "npm:8.29.1"
-    "@typescript-eslint/type-utils": "npm:8.29.1"
-    "@typescript-eslint/utils": "npm:8.29.1"
-    "@typescript-eslint/visitor-keys": "npm:8.29.1"
-    graphemer: "npm:^1.4.0"
-    ignore: "npm:^5.3.1"
-    natural-compare: "npm:^1.4.0"
-    ts-api-utils: "npm:^2.0.1"
-  peerDependencies:
-    "@typescript-eslint/parser": ^8.0.0 || ^8.0.0-alpha.0
-    eslint: ^8.57.0 || ^9.0.0
-    typescript: ">=4.8.4 <5.9.0"
-  checksum: 10c0/a3ed7556edcac374cab622862f2f9adedc91ca305d6937db6869a0253d675858c296cb5413980e8404fc39737117faaf35b00c6804664b3c542bdc417502532f
-  languageName: node
-  linkType: hard
-
-"@typescript-eslint/parser@npm:8.30.1":
-  version: 8.30.1
-  resolution: "@typescript-eslint/parser@npm:8.30.1"
-  dependencies:
-    "@typescript-eslint/scope-manager": "npm:8.30.1"
-    "@typescript-eslint/types": "npm:8.30.1"
-    "@typescript-eslint/typescript-estree": "npm:8.30.1"
-    "@typescript-eslint/visitor-keys": "npm:8.30.1"
+    "@typescript-eslint/scope-manager": "npm:8.31.1"
+    "@typescript-eslint/types": "npm:8.31.1"
+    "@typescript-eslint/typescript-estree": "npm:8.31.1"
+    "@typescript-eslint/visitor-keys": "npm:8.31.1"
     debug: "npm:^4.3.4"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <5.9.0"
-  checksum: 10c0/add025d5cfca5cd4d1f74c9297e71de95c945f4efbe6cbfbc72e2cd794cd2684397c7d832bdb5177a1f54398111243d20bd0d2ffdb32a4d5230f1db7cd6fbfb6
-  languageName: node
-  linkType: hard
-
-"@typescript-eslint/parser@npm:~8.29.1":
-  version: 8.29.1
-  resolution: "@typescript-eslint/parser@npm:8.29.1"
-  dependencies:
-    "@typescript-eslint/scope-manager": "npm:8.29.1"
-    "@typescript-eslint/types": "npm:8.29.1"
-    "@typescript-eslint/typescript-estree": "npm:8.29.1"
-    "@typescript-eslint/visitor-keys": "npm:8.29.1"
-    debug: "npm:^4.3.4"
-  peerDependencies:
-    eslint: ^8.57.0 || ^9.0.0
-    typescript: ">=4.8.4 <5.9.0"
-  checksum: 10c0/af3570ff58c42c2014e5c117bebf91120737fb139d94415ca2711844990e95252c3006ccc699871fe3f592cc1a3f4ebfdc9dd5f6cb29b6b128c2524fcf311b75
+  checksum: 10c0/4fffaddbe443fc6a512042b6a777a8b7d9775938b26f54d86279b232b9b3967d90d6bfd65aca0ff010d377855df19708c918545f51cedc51b1688726201added
   languageName: node
   linkType: hard
 
@@ -2115,43 +2062,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/scope-manager@npm:8.30.1":
-  version: 8.30.1
-  resolution: "@typescript-eslint/scope-manager@npm:8.30.1"
+"@typescript-eslint/scope-manager@npm:8.31.1":
+  version: 8.31.1
+  resolution: "@typescript-eslint/scope-manager@npm:8.31.1"
   dependencies:
-    "@typescript-eslint/types": "npm:8.30.1"
-    "@typescript-eslint/visitor-keys": "npm:8.30.1"
-  checksum: 10c0/8560fd02bb2a73b56f79af1dfa311491926f3625a04c0f32777c7c0bdec47b4a677addf2d2e2cc313416bb59b7a6e0bff7837449816a5ec5ff81e923daa76ca7
+    "@typescript-eslint/types": "npm:8.31.1"
+    "@typescript-eslint/visitor-keys": "npm:8.31.1"
+  checksum: 10c0/759cfaa922f8bc97ecdcfe583df88ad31b04d02a865efc2c6dab622374c9f32839054596193ec3b1c478d8a73690999cbd996e1092605f41a54bbe6a9a62bbf3
   languageName: node
   linkType: hard
 
-"@typescript-eslint/type-utils@npm:8.29.1":
-  version: 8.29.1
-  resolution: "@typescript-eslint/type-utils@npm:8.29.1"
+"@typescript-eslint/type-utils@npm:8.31.1":
+  version: 8.31.1
+  resolution: "@typescript-eslint/type-utils@npm:8.31.1"
   dependencies:
-    "@typescript-eslint/typescript-estree": "npm:8.29.1"
-    "@typescript-eslint/utils": "npm:8.29.1"
+    "@typescript-eslint/typescript-estree": "npm:8.31.1"
+    "@typescript-eslint/utils": "npm:8.31.1"
     debug: "npm:^4.3.4"
     ts-api-utils: "npm:^2.0.1"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <5.9.0"
-  checksum: 10c0/72cc01dbac866b0a7c7b1f637ad03ffd22f6d3617f70f06f485cf3096fddfc821fdc56de1a072cc6af70250c63698a3e5a910f67fe46eea941955b6e0da1b2bd
-  languageName: node
-  linkType: hard
-
-"@typescript-eslint/type-utils@npm:8.30.1":
-  version: 8.30.1
-  resolution: "@typescript-eslint/type-utils@npm:8.30.1"
-  dependencies:
-    "@typescript-eslint/typescript-estree": "npm:8.30.1"
-    "@typescript-eslint/utils": "npm:8.30.1"
-    debug: "npm:^4.3.4"
-    ts-api-utils: "npm:^2.0.1"
-  peerDependencies:
-    eslint: ^8.57.0 || ^9.0.0
-    typescript: ">=4.8.4 <5.9.0"
-  checksum: 10c0/c233d2b0b06bd8eca4ee38aebb7544d4084143590328f38c00302f98a62b06868394d4ab1cd798af68d5a47efd84976cc14d415e9e519396dc89aa8d4d47c9ee
+  checksum: 10c0/ea5369cf200cd48f26e2c6013c81f5915cc933117e011537a7424402a1ebececc8a39e290b9572a7876a237116fbd75e9ba9313c9898ab828f5a814ab26066d2
   languageName: node
   linkType: hard
 
@@ -2162,10 +2094,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:8.30.1":
-  version: 8.30.1
-  resolution: "@typescript-eslint/types@npm:8.30.1"
-  checksum: 10c0/461e800bf911c24d9b61bdbeed897921454acc0c24b4e8a79f943c14234241828c13a31dce31dcce77511185f806a2fb94769075e122e3182ba5a32dd55573eb
+"@typescript-eslint/types@npm:8.31.1":
+  version: 8.31.1
+  resolution: "@typescript-eslint/types@npm:8.31.1"
+  checksum: 10c0/d52692559028b71d8bfda4f098c7fa08e272c11cf9dd99ea9e1cfb00036c0849d6d53694e047a942c6568b3bf5637512e46356de70b412a9216ec6cfb8b2b950
   languageName: node
   linkType: hard
 
@@ -2187,12 +2119,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/typescript-estree@npm:8.30.1":
-  version: 8.30.1
-  resolution: "@typescript-eslint/typescript-estree@npm:8.30.1"
+"@typescript-eslint/typescript-estree@npm:8.31.1":
+  version: 8.31.1
+  resolution: "@typescript-eslint/typescript-estree@npm:8.31.1"
   dependencies:
-    "@typescript-eslint/types": "npm:8.30.1"
-    "@typescript-eslint/visitor-keys": "npm:8.30.1"
+    "@typescript-eslint/types": "npm:8.31.1"
+    "@typescript-eslint/visitor-keys": "npm:8.31.1"
     debug: "npm:^4.3.4"
     fast-glob: "npm:^3.3.2"
     is-glob: "npm:^4.0.3"
@@ -2201,11 +2133,26 @@ __metadata:
     ts-api-utils: "npm:^2.0.1"
   peerDependencies:
     typescript: ">=4.8.4 <5.9.0"
-  checksum: 10c0/9eb0b1bc4b5df37c84ac411d77ce0edf934b5fdde021ed45c984aa7894132ff7a276d2b95e2d29ef84c411df8ecdf096eec3e07ec1ee5b1fa8c623d40a82ecf0
+  checksum: 10c0/77059f204389d2d1b6db32d4df63473c99f5bd051218200f257531c2d2b2e3f237b23aa80a79baebc9ca8a776636867f1fd2d03533d207da2685d740e2c7fbef
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:8.29.1, @typescript-eslint/utils@npm:^6.0.0 || ^7.0.0 || ^8.0.0, @typescript-eslint/utils@npm:^8.15.0, @typescript-eslint/utils@npm:^8.23.0":
+"@typescript-eslint/utils@npm:8.31.1":
+  version: 8.31.1
+  resolution: "@typescript-eslint/utils@npm:8.31.1"
+  dependencies:
+    "@eslint-community/eslint-utils": "npm:^4.4.0"
+    "@typescript-eslint/scope-manager": "npm:8.31.1"
+    "@typescript-eslint/types": "npm:8.31.1"
+    "@typescript-eslint/typescript-estree": "npm:8.31.1"
+  peerDependencies:
+    eslint: ^8.57.0 || ^9.0.0
+    typescript: ">=4.8.4 <5.9.0"
+  checksum: 10c0/6190551702605aa60e67828163cb5880eee7ab5f1ee789d32227e4f4297d80ea9be98776400fd0660551dcbcac2a35babef33dd94267856dcb6f36c9c94f11ab
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/utils@npm:^6.0.0 || ^7.0.0 || ^8.0.0, @typescript-eslint/utils@npm:^8.15.0, @typescript-eslint/utils@npm:^8.23.0":
   version: 8.29.1
   resolution: "@typescript-eslint/utils@npm:8.29.1"
   dependencies:
@@ -2220,21 +2167,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:8.30.1":
-  version: 8.30.1
-  resolution: "@typescript-eslint/utils@npm:8.30.1"
-  dependencies:
-    "@eslint-community/eslint-utils": "npm:^4.4.0"
-    "@typescript-eslint/scope-manager": "npm:8.30.1"
-    "@typescript-eslint/types": "npm:8.30.1"
-    "@typescript-eslint/typescript-estree": "npm:8.30.1"
-  peerDependencies:
-    eslint: ^8.57.0 || ^9.0.0
-    typescript: ">=4.8.4 <5.9.0"
-  checksum: 10c0/ad54aa386edc2e19957c73ef25eea3e263e7e15e941c72e91ca6c8ea2536979d343a6069de0e40b15f0e732ddaacbfcc3d5f25a1583e11a32120c42c471802ea
-  languageName: node
-  linkType: hard
-
 "@typescript-eslint/visitor-keys@npm:8.29.1":
   version: 8.29.1
   resolution: "@typescript-eslint/visitor-keys@npm:8.29.1"
@@ -2245,13 +2177,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/visitor-keys@npm:8.30.1":
-  version: 8.30.1
-  resolution: "@typescript-eslint/visitor-keys@npm:8.30.1"
+"@typescript-eslint/visitor-keys@npm:8.31.1":
+  version: 8.31.1
+  resolution: "@typescript-eslint/visitor-keys@npm:8.31.1"
   dependencies:
-    "@typescript-eslint/types": "npm:8.30.1"
+    "@typescript-eslint/types": "npm:8.31.1"
     eslint-visitor-keys: "npm:^4.2.0"
-  checksum: 10c0/bdc182289c68a5c8f891f9aecf6ccb59743c3f2b1bbe57f57f8c7ce1688f4381182e301919895cefc929539eea914eeb847f7d351cdc3f685ed6c5ee67a10c9e
+  checksum: 10c0/09dbd8e1fdff72802a10bae2c12fa6d25f7e2dab1ff9b720afc2eb4e848b723c179109032aeaeb409d0c9e4107ab4fab8c8b1b47a55d58713d3f29a1365db3ea
   languageName: node
   linkType: hard
 
@@ -2553,10 +2485,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"awesome-phonenumber@npm:~7.4.0":
-  version: 7.4.0
-  resolution: "awesome-phonenumber@npm:7.4.0"
-  checksum: 10c0/294fe6c291799198ecd30f386da6702e61b804b68635bccc762f41a6f7da6b84bda3ba8722b164b3aa3e255c746554f705d2f8b300e4436041dddf613f9aa2f0
+"awesome-phonenumber@npm:~7.5.0":
+  version: 7.5.0
+  resolution: "awesome-phonenumber@npm:7.5.0"
+  checksum: 10c0/ec11a86f06db88ccb7592f7d326f77678aab2dbc7e3b59419c8b8c77d18eb13ccc51f55b1c41fed0068f340004fc9f3ffbc0f2d5dcc339396cb8f4ad00a270b7
   languageName: node
   linkType: hard
 
@@ -2950,14 +2882,14 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "chaos-assets-bundle@workspace:."
   dependencies:
-    "@terascope/eslint-config": "npm:~1.1.13"
-    "@terascope/job-components": "npm:~1.10.0"
-    "@terascope/scripts": "npm:~1.16.0"
+    "@terascope/eslint-config": "npm:~1.1.14"
+    "@terascope/job-components": "npm:~1.10.1"
+    "@terascope/scripts": "npm:~1.16.1"
     "@types/express": "npm:~5.0.1"
     "@types/fs-extra": "npm:~11.0.4"
     "@types/jest": "npm:~29.5.14"
     "@types/json2csv": "npm:~5.0.7"
-    "@types/node": "npm:~22.15.3"
+    "@types/node": "npm:~22.15.17"
     "@types/node-gzip": "npm:~1.1.3"
     "@types/semver": "npm:~7.7.0"
     "@types/timsort": "npm:~0.3.3"
@@ -2978,13 +2910,13 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "chaos@workspace:asset"
   dependencies:
-    "@terascope/data-mate": "npm:~1.8.0"
-    "@terascope/job-components": "npm:~1.10.0"
-    "@terascope/teraslice-state-storage": "npm:~1.9.0"
-    "@terascope/utils": "npm:~1.8.0"
+    "@terascope/data-mate": "npm:~1.8.1"
+    "@terascope/job-components": "npm:~1.10.1"
+    "@terascope/teraslice-state-storage": "npm:~1.9.1"
+    "@terascope/utils": "npm:~1.8.1"
     "@types/express": "npm:~5.0.1"
     express: "npm:~5.1.0"
-    ts-transforms: "npm:~1.8.0"
+    ts-transforms: "npm:~1.8.1"
     tslib: "npm:~2.8.1"
   languageName: unknown
   linkType: soft
@@ -4003,56 +3935,6 @@ __metadata:
   version: 4.2.0
   resolution: "eslint-visitor-keys@npm:4.2.0"
   checksum: 10c0/2ed81c663b147ca6f578312919483eb040295bbab759e5a371953456c636c5b49a559883e2677112453728d66293c0a4c90ab11cab3428cf02a0236d2e738269
-  languageName: node
-  linkType: hard
-
-"eslint@npm:~9.24.0":
-  version: 9.24.0
-  resolution: "eslint@npm:9.24.0"
-  dependencies:
-    "@eslint-community/eslint-utils": "npm:^4.2.0"
-    "@eslint-community/regexpp": "npm:^4.12.1"
-    "@eslint/config-array": "npm:^0.20.0"
-    "@eslint/config-helpers": "npm:^0.2.0"
-    "@eslint/core": "npm:^0.12.0"
-    "@eslint/eslintrc": "npm:^3.3.1"
-    "@eslint/js": "npm:9.24.0"
-    "@eslint/plugin-kit": "npm:^0.2.7"
-    "@humanfs/node": "npm:^0.16.6"
-    "@humanwhocodes/module-importer": "npm:^1.0.1"
-    "@humanwhocodes/retry": "npm:^0.4.2"
-    "@types/estree": "npm:^1.0.6"
-    "@types/json-schema": "npm:^7.0.15"
-    ajv: "npm:^6.12.4"
-    chalk: "npm:^4.0.0"
-    cross-spawn: "npm:^7.0.6"
-    debug: "npm:^4.3.2"
-    escape-string-regexp: "npm:^4.0.0"
-    eslint-scope: "npm:^8.3.0"
-    eslint-visitor-keys: "npm:^4.2.0"
-    espree: "npm:^10.3.0"
-    esquery: "npm:^1.5.0"
-    esutils: "npm:^2.0.2"
-    fast-deep-equal: "npm:^3.1.3"
-    file-entry-cache: "npm:^8.0.0"
-    find-up: "npm:^5.0.0"
-    glob-parent: "npm:^6.0.2"
-    ignore: "npm:^5.2.0"
-    imurmurhash: "npm:^0.1.4"
-    is-glob: "npm:^4.0.0"
-    json-stable-stringify-without-jsonify: "npm:^1.0.1"
-    lodash.merge: "npm:^4.6.2"
-    minimatch: "npm:^3.1.2"
-    natural-compare: "npm:^1.4.0"
-    optionator: "npm:^0.9.3"
-  peerDependencies:
-    jiti: "*"
-  peerDependenciesMeta:
-    jiti:
-      optional: true
-  bin:
-    eslint: bin/eslint.js
-  checksum: 10c0/f758ff1b9d2f2af5335f562f3f40aa8f71607b3edca33f7616840a222ed224555aeb3ac6943cc86e4f9ac5dc124a60bbfde624d054fb235631a8c04447e39ecc
   languageName: node
   linkType: hard
 
@@ -9015,14 +8897,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ts-transforms@npm:~1.8.0":
-  version: 1.8.0
-  resolution: "ts-transforms@npm:1.8.0"
+"ts-transforms@npm:~1.8.1":
+  version: 1.8.1
+  resolution: "ts-transforms@npm:1.8.1"
   dependencies:
-    "@terascope/data-mate": "npm:~1.8.0"
+    "@terascope/data-mate": "npm:~1.8.1"
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.8.0"
-    awesome-phonenumber: "npm:~7.4.0"
+    "@terascope/utils": "npm:~1.8.1"
+    awesome-phonenumber: "npm:~7.5.0"
     graphlib: "npm:~2.1.8"
     jexl: "npm:~2.3.0"
     nanoid: "npm:~5.1.5"
@@ -9032,7 +8914,7 @@ __metadata:
   bin:
     ts-match: ./bin/ts-transform.js
     ts-transform: ./bin/ts-transform.js
-  checksum: 10c0/693d62f62f6cc468c9932b94e9f12d93ee00ff71a74e55e33955d883ca5499272850b729e5dc92e381e361c4d2e2de3d90ba8a21384ed6b3fb08375703b81b14
+  checksum: 10c0/0a7fe51bd750b088e7ccc010aa15542a88fdc6d90cb610f2461fa137d5b8202a60613b154c3ac808c2238955363df25982ed447c4a30fcbdc8b9962fbf99c03e
   languageName: node
   linkType: hard
 
@@ -9156,18 +9038,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typedoc-plugin-markdown@npm:~4.6.2":
-  version: 4.6.2
-  resolution: "typedoc-plugin-markdown@npm:4.6.2"
+"typedoc-plugin-markdown@npm:~4.6.3":
+  version: 4.6.3
+  resolution: "typedoc-plugin-markdown@npm:4.6.3"
   peerDependencies:
     typedoc: 0.28.x
-  checksum: 10c0/0b0a8a174dfc9a0dee08878cf94b6e564612f3477e664d7254b0bf2703fcff14b496ad5de431cd5ec9773f128764043971b196ab3c9c8fdc66dda4eb0e6ff7f8
+  checksum: 10c0/5242ef2869bfb6dfbe6b3dbe655be8cb1147ed5f17fa3639ed7643ce889534ef27dfb91170f34fd52a83bf89bdb568a5a7a7ad148bbf0b5785cabc7c81dbcb2d
   languageName: node
   linkType: hard
 
-"typedoc@npm:~0.28.2":
-  version: 0.28.3
-  resolution: "typedoc@npm:0.28.3"
+"typedoc@npm:~0.28.4":
+  version: 0.28.4
+  resolution: "typedoc@npm:0.28.4"
   dependencies:
     "@gerrit0/mini-shiki": "npm:^3.2.2"
     lunr: "npm:^2.3.9"
@@ -9178,21 +9060,21 @@ __metadata:
     typescript: 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x
   bin:
     typedoc: bin/typedoc
-  checksum: 10c0/05cd7c26de0d760743c99a2c00e03eb1500c4fd5d355e5f0c7f9d29d514cb21b1064e436f82add431413ca93ff8dcd4c062b06bfd04337e9a75a3a879147b7dc
+  checksum: 10c0/5c7f4019da81e8b0869e4757b3d74c001dc021be381c5716a14212fbf63ad81bcfc470e040b7eac132603447c367019d5acab323d1b358b040979f1f56fe6393
   languageName: node
   linkType: hard
 
-"typescript-eslint@npm:~8.30.1":
-  version: 8.30.1
-  resolution: "typescript-eslint@npm:8.30.1"
+"typescript-eslint@npm:~8.31.1":
+  version: 8.31.1
+  resolution: "typescript-eslint@npm:8.31.1"
   dependencies:
-    "@typescript-eslint/eslint-plugin": "npm:8.30.1"
-    "@typescript-eslint/parser": "npm:8.30.1"
-    "@typescript-eslint/utils": "npm:8.30.1"
+    "@typescript-eslint/eslint-plugin": "npm:8.31.1"
+    "@typescript-eslint/parser": "npm:8.31.1"
+    "@typescript-eslint/utils": "npm:8.31.1"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <5.9.0"
-  checksum: 10c0/41c53910308fa03d2216ccae9885e82422b8abc96b384a6e47277b5b351f462e6da3a4dfbb8c9bc7defa8c96fb71c4371fa5759eaa86c7c1b3b53a4a9994e6ab
+  checksum: 10c0/58c096b96cb2262df3e3b52f06c0fc2020dc9f9d34b8a3d5331b0c7895e949ba1de43b7406d34b3cface2d1634f7e947e4c7759bf33819c92f8fb2bd67681bf1
   languageName: node
   linkType: hard
 
@@ -9559,15 +9441,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"xlucene-parser@npm:~1.8.0":
-  version: 1.8.0
-  resolution: "xlucene-parser@npm:1.8.0"
+"xlucene-parser@npm:~1.8.1":
+  version: 1.8.1
+  resolution: "xlucene-parser@npm:1.8.1"
   dependencies:
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.8.0"
+    "@terascope/utils": "npm:~1.8.1"
     peggy: "npm:~4.2.0"
     ts-pegjs: "npm:~4.2.1"
-  checksum: 10c0/e673cd7861d70c6892e231eff484da273bd2b7945404b3715e5c7beb979c7b8889bf6b8b71fef60ee6ff0d89095ec013e01232026a8064cdb93076d21c88af53
+  checksum: 10c0/1a98a28393320c9b1255b1f73e94ffcecaa25b0ffdf1951a7d35807a65b85f54d457bd749f492d1d6c48e1b668865a49af54f8430cd5df5b6115586271c16b53
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR updates the following dependencies:

- Bumps **Chaos-Assets** from `v1.1.0` to `v1.1.1`

## Choas-Assets
- @terascope/data-mate: `v1.8.1`
- @terascope/job-components: `v1.10.1"`
- @terascope/teraslice-state-storage: `v1.9.1`
- @terascope/utils: `v1.8.1`
- ts-transforms: `v1.8.1`

## Workspace
- @terascope/eslint-config: `v1.1.14`
- @terascope/job-components: `v1.10.1`
- @terascope/scripts: `v1.16.1`
- @types/node: `v22.15.17`