### PR TITLE
bundled deps update 2025-08-18

### DIFF
--- a/asset/package.json
+++ b/asset/package.json
@@ -21,7 +21,7 @@
         "test": "yarn --cwd ../ test"
     },
     "dependencies": {
-        "@terascope/data-mate": "~1.11.2",
+        "@terascope/data-mate": "~1.12.0",
         "@terascope/job-components": "~1.12.2",
         "@terascope/teraslice-state-storage": "~1.12.2",
         "@terascope/utils": "~1.10.2",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "devDependencies": {
         "@terascope/eslint-config": "~1.1.23",
         "@terascope/job-components": "~1.12.2",
-        "@terascope/scripts": "~1.21.3",
+        "@terascope/scripts": "~1.21.4",
         "@types/express": "~5.0.3",
         "@types/fs-extra": "~11.0.4",
         "@types/jest": "~30.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1483,15 +1483,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@terascope/data-mate@npm:~1.11.2":
-  version: 1.11.2
-  resolution: "@terascope/data-mate@npm:1.11.2"
+"@terascope/data-mate@npm:~1.12.0":
+  version: 1.12.0
+  resolution: "@terascope/data-mate@npm:1.12.0"
   dependencies:
     "@terascope/data-types": "npm:~1.11.2"
     "@terascope/types": "npm:~1.4.4"
     "@terascope/utils": "npm:~1.10.2"
     "@types/validator": "npm:~13.12.3"
     awesome-phonenumber: "npm:~7.5.0"
+    big-json: "npm:^3.2.0"
     date-fns: "npm:~4.1.0"
     ip-bigint: "npm:~8.2.1"
     ip6addr: "npm:~0.2.5"
@@ -1503,7 +1504,7 @@ __metadata:
     valid-url: "npm:~1.0.9"
     validator: "npm:~13.12.0"
     xlucene-parser: "npm:~1.10.2"
-  checksum: 10c0/e2fdeb01463b325fede920b290c223c21f22decc196fb7705ea3869780bf51c5665415edfa52852f8c146d856d04bbbc4bf86becca2e9e34ff5bdf5eeeff5811
+  checksum: 10c0/4e31f3c3b5ed33fa6126d1a3d6df7f1d679987d64cb0d879248118a807fd95b61c235908d33b21b3124cc28d1e0eb990ba8ddbdbcad91c39c3e02981971afaba
   languageName: node
   linkType: hard
 
@@ -1590,9 +1591,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@terascope/scripts@npm:~1.21.3":
-  version: 1.21.3
-  resolution: "@terascope/scripts@npm:1.21.3"
+"@terascope/scripts@npm:~1.21.4":
+  version: 1.21.4
+  resolution: "@terascope/scripts@npm:1.21.4"
   dependencies:
     "@kubernetes/client-node": "npm:~1.3.0"
     "@terascope/utils": "npm:~1.10.2"
@@ -1623,7 +1624,7 @@ __metadata:
       optional: true
   bin:
     ts-scripts: ./bin/ts-scripts.js
-  checksum: 10c0/24428d807691a10b0bc0cfe371b5674c1bbea1b950a326bd744bf73c562e3ae2f9c47bc5fba8e394d13630b206f2d2a3046deeeba9e0ecfa2a7bfa793d5019f7
+  checksum: 10c0/b7bf44f30f9fb3df17a30f91b98154b79db85d0653849bb6c264020ae1e4553c1ba5cb1ce2af5f26f50d5cfd27ea4f99033cea4b831a52b7ca1780bca7080f31
   languageName: node
   linkType: hard
 
@@ -2747,6 +2748,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"JSONStream@npm:^1.3.1":
+  version: 1.3.5
+  resolution: "JSONStream@npm:1.3.5"
+  dependencies:
+    jsonparse: "npm:^1.2.0"
+    through: "npm:>=2.2.7 <3"
+  bin:
+    JSONStream: ./bin.js
+  checksum: 10c0/0f54694da32224d57b715385d4a6b668d2117379d1f3223dc758459246cca58fdc4c628b83e8a8883334e454a0a30aa198ede77c788b55537c1844f686a751f2
+  languageName: node
+  linkType: hard
+
 "abbrev@npm:^3.0.0":
   version: 3.0.1
   resolution: "abbrev@npm:3.0.1"
@@ -3239,6 +3252,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"big-json@npm:^3.2.0":
+  version: 3.2.0
+  resolution: "big-json@npm:3.2.0"
+  dependencies:
+    JSONStream: "npm:^1.3.1"
+    assert-plus: "npm:^1.0.0"
+    into-stream: "npm:^5.1.0"
+    json-stream-stringify: "npm:^2.0.1"
+    once: "npm:^1.4.0"
+    through2: "npm:^3.0.1"
+  checksum: 10c0/866233c2598e9dc3a6113c9690fb5a3e79fff060a6e66992f3a64a1a3e8dda607d2234b7ce8806acd87c40d6c2cffd9bdc64843b4d4d87925d65fc15dfcf8dcd
+  languageName: node
+  linkType: hard
+
 "bintrees@npm:1.0.2":
   version: 1.0.2
   resolution: "bintrees@npm:1.0.2"
@@ -3539,7 +3566,7 @@ __metadata:
   dependencies:
     "@terascope/eslint-config": "npm:~1.1.23"
     "@terascope/job-components": "npm:~1.12.2"
-    "@terascope/scripts": "npm:~1.21.3"
+    "@terascope/scripts": "npm:~1.21.4"
     "@types/express": "npm:~5.0.3"
     "@types/fs-extra": "npm:~11.0.4"
     "@types/jest": "npm:~30.0.0"
@@ -3565,7 +3592,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "chaos@workspace:asset"
   dependencies:
-    "@terascope/data-mate": "npm:~1.11.2"
+    "@terascope/data-mate": "npm:~1.12.0"
     "@terascope/job-components": "npm:~1.12.2"
     "@terascope/teraslice-state-storage": "npm:~1.12.2"
     "@terascope/utils": "npm:~1.10.2"
@@ -5191,6 +5218,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"from2@npm:^2.3.0":
+  version: 2.3.0
+  resolution: "from2@npm:2.3.0"
+  dependencies:
+    inherits: "npm:^2.0.1"
+    readable-stream: "npm:^2.0.0"
+  checksum: 10c0/f87f7a2e4513244d551454a7f8324ef1f7837864a8701c536417286ec19ff4915606b1dfa8909a21b7591ebd8440ffde3642f7c303690b9a4d7c832d62248aa1
+  languageName: node
+  linkType: hard
+
 "fs-constants@npm:^1.0.0":
   version: 1.0.0
   resolution: "fs-constants@npm:1.0.0"
@@ -5834,7 +5871,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"inherits@npm:2, inherits@npm:2.0.4, inherits@npm:^2.0.3, inherits@npm:~2.0.3":
+"inherits@npm:2, inherits@npm:2.0.4, inherits@npm:^2.0.1, inherits@npm:^2.0.3, inherits@npm:^2.0.4, inherits@npm:~2.0.3":
   version: 2.0.4
   resolution: "inherits@npm:2.0.4"
   checksum: 10c0/4e531f648b29039fb7426fb94075e6545faa1eb9fe83c29f0b6d9e7263aceb4289d2d4557db0d428188eeb449cc7c5e77b0a0b2c4e248ff2a65933a0dee49ef2
@@ -5856,6 +5893,16 @@ __metadata:
     hasown: "npm:^2.0.2"
     side-channel: "npm:^1.1.0"
   checksum: 10c0/03966f5e259b009a9bf1a78d60da920df198af4318ec004f57b8aef1dd3fe377fbc8cce63a96e8c810010302654de89f9e19de1cd8ad0061d15be28a695465c7
+  languageName: node
+  linkType: hard
+
+"into-stream@npm:^5.1.0":
+  version: 5.1.1
+  resolution: "into-stream@npm:5.1.1"
+  dependencies:
+    from2: "npm:^2.3.0"
+    p-is-promise: "npm:^3.0.0"
+  checksum: 10c0/7c05dd20d1b4c17db7ed8215c0787b9cfdcd676e2d98d81bc9ee00b5b7932c45ea95cca172362e255b29a3c9a9951d6ddab8fdbf0276aeec3e50324f6425190b
   languageName: node
   linkType: hard
 
@@ -7040,6 +7087,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"json-stream-stringify@npm:^2.0.1":
+  version: 2.0.4
+  resolution: "json-stream-stringify@npm:2.0.4"
+  checksum: 10c0/ac47f58dd1e2116fd49e1126ebff125d38442a274793f021654e5634a07350a21dc77fff8833905e1bca45c8f6d6c4aa14c2b22573c685fde476e07b6d0e7806
+  languageName: node
+  linkType: hard
+
 "json5@npm:^1.0.2":
   version: 1.0.2
   resolution: "json5@npm:1.0.2"
@@ -7070,6 +7124,13 @@ __metadata:
     graceful-fs:
       optional: true
   checksum: 10c0/4f95b5e8a5622b1e9e8f33c96b7ef3158122f595998114d1e7f03985649ea99cb3cd99ce1ed1831ae94c8c8543ab45ebd044207612f31a56fd08462140e46865
+  languageName: node
+  linkType: hard
+
+"jsonparse@npm:^1.2.0":
+  version: 1.3.1
+  resolution: "jsonparse@npm:1.3.1"
+  checksum: 10c0/89bc68080cd0a0e276d4b5ab1b79cacd68f562467008d176dc23e16e97d4efec9e21741d92ba5087a8433526a45a7e6a9d5ef25408696c402ca1cfbc01a90bf0
   languageName: node
   linkType: hard
 
@@ -7955,6 +8016,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"p-is-promise@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "p-is-promise@npm:3.0.0"
+  checksum: 10c0/17a52c7a59a31a435a4721a7110faeccb7cc9179cf9cd00016b7a9a7156e2c2ed9d8e2efc0142acab74d5064fbb443eaeaf67517cf3668f2a7c93a7effad5bb9
+  languageName: node
+  linkType: hard
+
 "p-limit@npm:^1.1.0":
   version: 1.3.0
   resolution: "p-limit@npm:1.3.0"
@@ -8553,7 +8621,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"readable-stream@npm:^2.3.0, readable-stream@npm:^2.3.5":
+"readable-stream@npm:2 || 3, readable-stream@npm:^3.0.2":
+  version: 3.6.2
+  resolution: "readable-stream@npm:3.6.2"
+  dependencies:
+    inherits: "npm:^2.0.3"
+    string_decoder: "npm:^1.1.1"
+    util-deprecate: "npm:^1.0.1"
+  checksum: 10c0/e37be5c79c376fdd088a45fa31ea2e423e5d48854be7a22a58869b4e84d25047b193f6acb54f1012331e1bcd667ffb569c01b99d36b0bd59658fb33f513511b7
+  languageName: node
+  linkType: hard
+
+"readable-stream@npm:^2.0.0, readable-stream@npm:^2.3.0, readable-stream@npm:^2.3.5":
   version: 2.3.8
   resolution: "readable-stream@npm:2.3.8"
   dependencies:
@@ -8565,17 +8644,6 @@ __metadata:
     string_decoder: "npm:~1.1.1"
     util-deprecate: "npm:~1.0.1"
   checksum: 10c0/7efdb01f3853bc35ac62ea25493567bf588773213f5f4a79f9c365e1ad13bab845ac0dae7bc946270dc40c3929483228415e92a3fc600cc7e4548992f41ee3fa
-  languageName: node
-  linkType: hard
-
-"readable-stream@npm:^3.0.2":
-  version: 3.6.2
-  resolution: "readable-stream@npm:3.6.2"
-  dependencies:
-    inherits: "npm:^2.0.3"
-    string_decoder: "npm:^1.1.1"
-    util-deprecate: "npm:^1.0.1"
-  checksum: 10c0/e37be5c79c376fdd088a45fa31ea2e423e5d48854be7a22a58869b4e84d25047b193f6acb54f1012331e1bcd667ffb569c01b99d36b0bd59658fb33f513511b7
   languageName: node
   linkType: hard
 
@@ -9647,7 +9715,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"through@npm:^2.3.8":
+"through2@npm:^3.0.1":
+  version: 3.0.2
+  resolution: "through2@npm:3.0.2"
+  dependencies:
+    inherits: "npm:^2.0.4"
+    readable-stream: "npm:2 || 3"
+  checksum: 10c0/8ea17efa2ce5b78ef5c52d08e29d0dbdad9c321c2add5192bba3434cae25b2319bf9cdac1c54c3bfbd721438a30565ca6f3f19eb79f62341dafc5a12429d2ccc
+  languageName: node
+  linkType: hard
+
+"through@npm:>=2.2.7 <3, through@npm:^2.3.8":
   version: 2.3.8
   resolution: "through@npm:2.3.8"
   checksum: 10c0/4b09f3774099de0d4df26d95c5821a62faee32c7e96fb1f4ebd54a2d7c11c57fe88b0a0d49cf375de5fee5ae6bf4eb56dbbf29d07366864e2ee805349970d3cc


### PR DESCRIPTION
This PR updates the following dependencies:

## Choas-Assets

- @terascope/data-mate: `v1.12.0`
- @terascope/job-components: `v1.12.2`
- @terascope/teraslice-state-storage: `v1.12.2`
- @terascope/utils: `v1.10.2`

## Workspace 

- @terascope/eslint-config: `v1.1.23`
- @terascope/job-components: `v1.12.2`
- @terascope/scripts: `v1.21.4`