### PR TITLE
Add OOM slicer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # chaos-assets
 
-> Teraslice chaos asset bundle
+> Teraslice chaos asset bundle. Used to intentionally create errors in teraslice jobs for testing and debugging.
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Any manual changes will be lost next time this gets auto-generated. -->
 - [kafka_queue_buster_generator](./docs/asset/operations/kafka_queue_buster_generator)
 - [kafka_queue_buster_length](./docs/asset/operations/kafka_queue_buster_length)
 - [kafka_queue_buster_size](./docs/asset/operations/kafka_queue_buster_size)
+- [oom_slicer](./docs/asset/operations/oom_slicer)
 
 ## Contributing
 

--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,6 +1,6 @@
 {
     "name": "chaos",
-    "version": "2.2.0",
+    "version": "2.3.0",
     "description": "An asset bundle for developers",
     "minimum_teraslice_version": "3.0.0"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -23,7 +23,8 @@
         "@terascope/teraslice-state-storage": "~2.5.1",
         "@types/express": "~5.0.5",
         "express": "~5.2.1",
-        "tslib": "~2.8.1"
+        "tslib": "~2.8.1",
+        "uuid": "^14.0.0"
     },
     "engines": {
         "node": ">=22.0.0",

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,7 +1,7 @@
 {
     "name": "chaos",
     "displayName": "Asset",
-    "version": "2.2.0",
+    "version": "2.3.0",
     "private": true,
     "description": "An asset bundle for developers",
     "repository": {

--- a/asset/src/index.ts
+++ b/asset/src/index.ts
@@ -21,6 +21,10 @@ import KafkaQueueBusterLengthSchema from '../src/kafka_queue_buster_length/schem
 import KafkaQueueBusterSize from '../src/kafka_queue_buster_size/processor';
 import KafkaQueueBusterSizeSchema from '../src/kafka_queue_buster_size/schema';
 
+import OomSlicerFetcher from '../src/oom_slicer/fetcher';
+import OomSlicerSchema from '../src/oom_slicer/schema';
+import OomSlicerSlicer from '../src/oom_slicer/slicer';
+
 export const ASSETS = {
     duplicate_key_counter: {
         Processor: DuplicateKeyCounter,
@@ -47,5 +51,10 @@ export const ASSETS = {
     kafka_queue_buster_size: {
         Processor: KafkaQueueBusterSize,
         Schema: KafkaQueueBusterSizeSchema,
+    },
+    oom_slicer: {
+        Fetcher: OomSlicerFetcher,
+        Schema: OomSlicerSchema,
+        Slicer: OomSlicerSlicer,
     },
 };

--- a/asset/src/oom_slicer/fetcher.ts
+++ b/asset/src/oom_slicer/fetcher.ts
@@ -1,0 +1,14 @@
+import { Fetcher } from '@terascope/job-components';
+
+export default class OomFetcher extends Fetcher {
+    async fetch() {
+        const result = [];
+        for (let i = 0; i < 10; i++) {
+            result.push({
+                id: i,
+                data: [Math.random(), Math.random(), Math.random()],
+            });
+        }
+        return result;
+    }
+}

--- a/asset/src/oom_slicer/interfaces.ts
+++ b/asset/src/oom_slicer/interfaces.ts
@@ -1,0 +1,6 @@
+import { OpConfig } from '@terascope/types';
+
+export interface OomSlicer extends OpConfig {
+    bytes: number;
+    delay: number;
+}

--- a/asset/src/oom_slicer/interfaces.ts
+++ b/asset/src/oom_slicer/interfaces.ts
@@ -1,6 +1,6 @@
 import { OpConfig } from '@terascope/types';
 
-export interface OomSlicer extends OpConfig {
+export interface OomSlicerConfig extends OpConfig {
     bytes: number;
     delay: number;
 }

--- a/asset/src/oom_slicer/schema.ts
+++ b/asset/src/oom_slicer/schema.ts
@@ -1,0 +1,31 @@
+import { AnyObject, ConvictSchema } from '@terascope/job-components';
+import { OomSlicer } from './interfaces';
+
+export default class OomSchema extends ConvictSchema<OomSlicer> {
+    build(): AnyObject {
+        return {
+            bytes: {
+                doc: 'The number of random bytes to add to an array each slice. This large array will eventually use all available memory. Defaults to 524288 (0.5 mb)',
+                default: 524288,
+                format(val: any) {
+                    if (!Number.isInteger(val)) {
+                        throw new Error('Invalid bytes parameter for oom_slicer, must be a number');
+                    } else if (val <= 0) {
+                        throw new Error('Invalid bytes parameter for oom_slicer, must be greater than zero');
+                    }
+                }
+            },
+            fault_on_slice: {
+                doc: 'The number of milliseconds to delay on each slice. This can be used to adjust the time until the memory limit is reached. Defaults to 50',
+                default: 50,
+                format(val: any) {
+                    if (!Number.isInteger(val)) {
+                        throw new Error('Invalid delay parameter for oom_slicer, must be a number');
+                    } else if (val < 0) {
+                        throw new Error('Invalid delay parameter for oom_slicer, must be greater than or equal to zero');
+                    }
+                }
+            }
+        };
+    }
+}

--- a/asset/src/oom_slicer/schema.ts
+++ b/asset/src/oom_slicer/schema.ts
@@ -1,8 +1,9 @@
-import { AnyObject, ConvictSchema } from '@terascope/job-components';
-import { OomSlicer } from './interfaces';
+import { BaseSchema } from '@terascope/job-components';
+import { Terafoundation } from '@terascope/types';
+import { OomSlicerConfig } from './interfaces.js';
 
-export default class OomSchema extends ConvictSchema<OomSlicer> {
-    build(): AnyObject {
+export default class OomSchema extends BaseSchema<OomSlicerConfig> {
+    build(): Terafoundation.Schema<Omit<OomSlicerConfig, '_op'>> {
         return {
             bytes: {
                 doc: 'The number of random bytes to add to an array each slice. This large array will eventually use all available memory. Defaults to 524288 (0.5 mb)',

--- a/asset/src/oom_slicer/schema.ts
+++ b/asset/src/oom_slicer/schema.ts
@@ -16,7 +16,7 @@ export default class OomSchema extends BaseSchema<OomSlicerConfig> {
                     }
                 }
             },
-            fault_on_slice: {
+            delay: {
                 doc: 'The number of milliseconds to delay on each slice. This can be used to adjust the time until the memory limit is reached. Defaults to 50',
                 default: 50,
                 format(val: any) {

--- a/asset/src/oom_slicer/slicer.ts
+++ b/asset/src/oom_slicer/slicer.ts
@@ -1,0 +1,28 @@
+import { v4 as uuid } from 'uuid';
+import { Slicer, pDelay } from '@terascope/job-components';
+import crypto from 'crypto';
+import { OomSlicer } from './interfaces';
+
+export default class OOMSlicer extends Slicer {
+    oomArray: Array<Buffer>;
+    bytes: number;
+    delay: number;
+
+    constructor(...args: ConstructorParameters<typeof Slicer<OomSlicer>>) {
+        super(...args);
+        this.oomArray = [];
+        this.bytes = this.opConfig.bytes;
+        this.delay = this.opConfig.delay;
+    }
+
+    async slice() {
+        this.oomArray.push(crypto.randomBytes(this.bytes)); // 0.5 mb = 524288
+
+        await pDelay(this.delay);
+
+        return {
+            id: uuid(),
+            foo: 'bar',
+        };
+    }
+}

--- a/asset/src/oom_slicer/slicer.ts
+++ b/asset/src/oom_slicer/slicer.ts
@@ -1,14 +1,15 @@
-import { v4 as uuid } from 'uuid';
-import { Slicer, pDelay } from '@terascope/job-components';
 import crypto from 'crypto';
-import { OomSlicer } from './interfaces';
+import { v4 as uuid } from 'uuid';
+import { Slicer } from '@terascope/job-components';
+import { pDelay } from '@terascope/core-utils';
+import { OomSlicerConfig } from './interfaces.js';
 
 export default class OOMSlicer extends Slicer {
     oomArray: Array<Buffer>;
     bytes: number;
     delay: number;
 
-    constructor(...args: ConstructorParameters<typeof Slicer<OomSlicer>>) {
+    constructor(...args: ConstructorParameters<typeof Slicer<OomSlicerConfig>>) {
         super(...args);
         this.oomArray = [];
         this.bytes = this.opConfig.bytes;

--- a/docs/asset/operations/oom_slicer.md
+++ b/docs/asset/operations/oom_slicer.md
@@ -36,10 +36,9 @@ This example will cause the slicer to fail with an OOM error. Until then, it wil
 
 ```javascript
 Slice : {
-            id: '109156be-c4fb-41ea-b1b4-efe1671c5836,
-            foo: 'bar',
-        }
-
+    id: '109156be-c4fb-41ea-b1b4-efe1671c5836,
+    foo: 'bar',
+}
 ```
 
 The fetcher will then generate a batch of records based on the size specified in the job:

--- a/docs/asset/operations/oom_slicer.md
+++ b/docs/asset/operations/oom_slicer.md
@@ -1,0 +1,63 @@
+# oom_slicer
+
+A processor that causes the slicer to fail with an out of memory (OOM) error. It does this by
+filling an array with random bytes. Use the `bytes` configuration field to set how many bytes
+are added each slice and the `delay` field to speed up or slow down slice creation.
+
+## Usage
+
+### Cause the slicer to OOM
+
+Example of a job using the `oom_slicer` slicer
+
+```json
+{
+    "name" : "exc_oom",
+    "workers" : 1,
+    "lifecycle" : "persistent",
+    "assets" : [
+        "chaos"
+    ],
+    "operations" : [
+        {
+            "_op": "oom_slicer",
+            "bytes": "1000000",
+            "delay": 0
+
+        },
+        {
+            "_op": "noop"
+        },
+    ]
+}
+```
+
+This example will cause the slicer to fail with an OOM error. Until then, it will produce slices that look like below:
+
+```javascript
+Slice : {
+            id: '109156be-c4fb-41ea-b1b4-efe1671c5836,
+            foo: 'bar',
+        }
+
+```
+
+The fetcher will then generate a batch of records based on the size specified in the job:
+
+```javascript
+
+DataEntity [{
+    { id: 1, data: [Math.random(), Math.random(), Math.random()] },
+    { id: 2, data: [Math.random(), Math.random(), Math.random()] },
+    { id: 3, data: [Math.random(), Math.random(), Math.random()] }
+}]
+
+```
+
+## Parameters
+
+| Configuration | Description | Type |  Notes |
+| ------------- | ----------- | ---- | ------ |
+| _op | Name of operation, it must reflect the exact name of the file | String | required |
+| bytes | The number of random bytes to add to an array each slice. This large array will eventually use all available memory. | Integer | default `524288` (0.5 mb) |
+| delay | The number of milliseconds to delay on each slice. This can be used to adjust the time until the memory limit is reached. | Integer | default `50` |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "chaos-assets-bundle",
     "displayName": "Chaos Assets Bundle",
-    "version": "2.2.0",
+    "version": "2.3.0",
     "private": true,
     "description": "An asset bundle for developers",
     "type": "module",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,6 +107,9 @@ importers:
       tslib:
         specifier: ~2.8.1
         version: 2.8.1
+      uuid:
+        specifier: ^14.0.0
+        version: 14.0.0
 
 packages:
 
@@ -4278,6 +4281,10 @@ packages:
 
   uuid@13.0.0:
     resolution: {integrity: sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==}
+    hasBin: true
+
+  uuid@14.0.0:
+    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
 
   uuid@8.3.2:
@@ -9928,6 +9935,8 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   uuid@13.0.0: {}
+
+  uuid@14.0.0: {}
 
   uuid@8.3.2: {}
 

--- a/test/oom_slicer/fetcher-spec.ts
+++ b/test/oom_slicer/fetcher-spec.ts
@@ -1,0 +1,76 @@
+import 'jest-extended';
+import { JobConfigParams, OpConfig } from '@terascope/job-components';
+import { WorkerTestHarness } from 'teraslice-test-harness';
+
+describe('oom_slicer fetcher', () => {
+    let harness: WorkerTestHarness;
+
+    afterEach(async () => {
+        if (harness) await harness.shutdown();
+    });
+
+    async function makeFetcherTest(config: Partial<OpConfig> = {}) {
+        const opConfig = Object.assign({}, { _op: 'oom_slicer' }, config);
+        const job: JobConfigParams = {
+            name: 'test-job',
+            active: true,
+            analytics: false,
+            autorecover: false,
+            assets: [],
+            lifecycle: 'once',
+            max_retries: 0,
+            probation_window: 30000,
+            slicers: 1,
+            workers: 1,
+            env_vars: {},
+            apis: [],
+            operations: [
+                opConfig,
+                { _op: 'noop' },
+            ],
+        };
+        harness = new WorkerTestHarness(job);
+        await harness.initialize();
+        return harness;
+    }
+
+    it('should return 10 records', async () => {
+        const test = await makeFetcherTest();
+        const results = await test.runSlice({ id: 'test-slice', foo: 'bar' });
+
+        expect(results.length).toEqual(10);
+    });
+
+    it('should return records with id and data fields', async () => {
+        const test = await makeFetcherTest();
+        const results = await test.runSlice({ id: 'test-slice', foo: 'bar' });
+
+        for (let i = 0; i < 10; i++) {
+            expect(results[i]).toMatchObject({
+                id: i,
+                data: expect.arrayContaining([expect.any(Number)]),
+            });
+            expect(results[i].data).toHaveLength(3);
+        }
+    });
+
+    it('should return records with ids 0 through 9', async () => {
+        const test = await makeFetcherTest();
+        const results = await test.runSlice({ id: 'test-slice', foo: 'bar' });
+
+        const ids = results.map((r: any) => r.id);
+        expect(ids).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    });
+
+    it('should return data values that are numbers between 0 and 1', async () => {
+        const test = await makeFetcherTest();
+        const results = await test.runSlice({ id: 'test-slice', foo: 'bar' });
+
+        for (const record of results) {
+            for (const val of (record as any).data) {
+                expect(val).toBeGreaterThanOrEqual(0);
+                expect(val).toBeLessThan(1);
+            }
+        }
+    });
+});

--- a/test/oom_slicer/schema-spec.ts
+++ b/test/oom_slicer/schema-spec.ts
@@ -1,0 +1,75 @@
+import 'jest-extended';
+import { WorkerTestHarness } from 'teraslice-test-harness';
+import { JobConfigParams, OpConfig } from '@terascope/job-components';
+import { OomSlicerConfig } from '../../asset/src/oom_slicer/interfaces.js';
+
+describe('oom_slicer schema', () => {
+    let harness: WorkerTestHarness;
+
+    async function makeSchema(config: Partial<OpConfig> = {}): Promise<OomSlicerConfig> {
+        const name = 'oom_slicer';
+        const opConfig = Object.assign({}, { _op: name }, config);
+        const job: JobConfigParams = {
+            name: 'test-job',
+            active: true,
+            analytics: false,
+            autorecover: false,
+            assets: [],
+            lifecycle: 'once',
+            max_retries: 0,
+            probation_window: 30000,
+            slicers: 1,
+            workers: 1,
+            env_vars: {},
+            apis: [],
+            operations: [
+                opConfig,
+                { _op: 'noop' },
+            ],
+        };
+        harness = new WorkerTestHarness(job);
+        await harness.initialize();
+
+        const validConfig = harness.executionContext.config.operations.find(
+            (c) => c._op === name
+        );
+        return validConfig as OomSlicerConfig;
+    }
+
+    afterEach(async () => {
+        if (harness) await harness.shutdown();
+    });
+
+    it('should instantiate with defaults', async () => {
+        const schema = await makeSchema();
+
+        expect(schema).toBeDefined();
+        expect(schema.bytes).toEqual(524288);
+        expect((schema as any).fault_on_slice).toEqual(50);
+    });
+
+    it('should accept valid bytes values', async () => {
+        const schema = await makeSchema({ bytes: 1024 });
+        expect(schema.bytes).toEqual(1024);
+    });
+
+    it('should accept zero delay (fault_on_slice)', async () => {
+        const schema = await makeSchema({ fault_on_slice: 0 } as any);
+        expect((schema as any).fault_on_slice).toEqual(0);
+    });
+
+    it('should reject invalid bytes values', async () => {
+        await expect(makeSchema({ bytes: 0 })).toReject();
+        await expect(makeSchema({ bytes: -1 })).toReject();
+        await expect(makeSchema({ bytes: 1.5 })).toReject();
+        await expect(makeSchema({ bytes: 'large' as any })).toReject();
+        await expect(makeSchema({ bytes: {} as any })).toReject();
+    });
+
+    it('should reject invalid fault_on_slice values', async () => {
+        await expect(makeSchema({ fault_on_slice: -1 } as any)).toReject();
+        await expect(makeSchema({ fault_on_slice: 1.5 } as any)).toReject();
+        await expect(makeSchema({ fault_on_slice: 'fast' } as any)).toReject();
+        await expect(makeSchema({ fault_on_slice: [] } as any)).toReject();
+    });
+});

--- a/test/oom_slicer/schema-spec.ts
+++ b/test/oom_slicer/schema-spec.ts
@@ -45,7 +45,7 @@ describe('oom_slicer schema', () => {
 
         expect(schema).toBeDefined();
         expect(schema.bytes).toEqual(524288);
-        expect((schema as any).fault_on_slice).toEqual(50);
+        expect((schema as any).delay).toEqual(50);
     });
 
     it('should accept valid bytes values', async () => {
@@ -53,9 +53,9 @@ describe('oom_slicer schema', () => {
         expect(schema.bytes).toEqual(1024);
     });
 
-    it('should accept zero delay (fault_on_slice)', async () => {
-        const schema = await makeSchema({ fault_on_slice: 0 } as any);
-        expect((schema as any).fault_on_slice).toEqual(0);
+    it('should accept zero delay (delay)', async () => {
+        const schema = await makeSchema({ delay: 0 } as any);
+        expect((schema as any).delay).toEqual(0);
     });
 
     it('should reject invalid bytes values', async () => {
@@ -66,10 +66,10 @@ describe('oom_slicer schema', () => {
         await expect(makeSchema({ bytes: {} as any })).toReject();
     });
 
-    it('should reject invalid fault_on_slice values', async () => {
-        await expect(makeSchema({ fault_on_slice: -1 } as any)).toReject();
-        await expect(makeSchema({ fault_on_slice: 1.5 } as any)).toReject();
-        await expect(makeSchema({ fault_on_slice: 'fast' } as any)).toReject();
-        await expect(makeSchema({ fault_on_slice: [] } as any)).toReject();
+    it('should reject invalid delay values', async () => {
+        await expect(makeSchema({ delay: -1 } as any)).toReject();
+        await expect(makeSchema({ delay: 1.5 } as any)).toReject();
+        await expect(makeSchema({ delay: 'fast' } as any)).toReject();
+        await expect(makeSchema({ delay: [] } as any)).toReject();
     });
 });

--- a/test/oom_slicer/slicer-spec.ts
+++ b/test/oom_slicer/slicer-spec.ts
@@ -35,8 +35,9 @@ describe('oom_slicer slicer', () => {
         const test = await makeSlicerTest();
         const [slice] = await test.createSlices();
 
-        expect(typeof slice.id).toEqual('string');
-        expect(slice.id).toMatch(
+        expect(slice).not.toBeNull();
+        expect(typeof slice!.id).toEqual('string');
+        expect(slice!.id).toMatch(
             /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
         );
     });
@@ -47,8 +48,11 @@ describe('oom_slicer slicer', () => {
         const [slice2] = await test.createSlices();
         const [slice3] = await test.createSlices();
 
-        expect(slice1.id).not.toEqual(slice2.id);
-        expect(slice2.id).not.toEqual(slice3.id);
+        expect(slice1).not.toBeNull();
+        expect(slice2).not.toBeNull();
+        expect(slice3).not.toBeNull();
+        expect(slice1!.id).not.toEqual(slice2!.id);
+        expect(slice2!.id).not.toEqual(slice3!.id);
     });
 
     it('should accumulate memory in oomArray with each slice', async () => {

--- a/test/oom_slicer/slicer-spec.ts
+++ b/test/oom_slicer/slicer-spec.ts
@@ -1,0 +1,78 @@
+import { SlicerTestHarness, newTestJobConfig } from 'teraslice-test-harness';
+
+describe('oom_slicer slicer', () => {
+    let harness: SlicerTestHarness;
+
+    afterEach(async () => {
+        if (harness) await harness.shutdown();
+    });
+
+    async function makeSlicerTest(opConfig: Record<string, any> = {}) {
+        const job = newTestJobConfig({
+            analytics: true,
+            slicers: 1,
+            lifecycle: 'persistent',
+            operations: [
+                Object.assign({ _op: 'oom_slicer', delay: 0 }, opConfig),
+                { _op: 'noop' },
+            ],
+        });
+        harness = new SlicerTestHarness(job, {});
+        await harness.initialize();
+        return harness;
+    }
+
+    it('should return a slice with id and foo fields', async () => {
+        const test = await makeSlicerTest();
+        const [slice] = await test.createSlices();
+
+        expect(slice).toBeDefined();
+        expect(slice).toHaveProperty('id');
+        expect(slice).toHaveProperty('foo', 'bar');
+    });
+
+    it('should return a UUID as the slice id', async () => {
+        const test = await makeSlicerTest();
+        const [slice] = await test.createSlices();
+
+        expect(typeof slice.id).toEqual('string');
+        expect(slice.id).toMatch(
+            /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+        );
+    });
+
+    it('should return unique ids on each slice', async () => {
+        const test = await makeSlicerTest();
+        const [slice1] = await test.createSlices();
+        const [slice2] = await test.createSlices();
+        const [slice3] = await test.createSlices();
+
+        expect(slice1.id).not.toEqual(slice2.id);
+        expect(slice2.id).not.toEqual(slice3.id);
+    });
+
+    it('should accumulate memory in oomArray with each slice', async () => {
+        const test = await makeSlicerTest({ bytes: 1024 });
+        const slicer = (test as any).executionContext._slicer as any;
+
+        expect(slicer.oomArray).toHaveLength(0);
+
+        await test.createSlices();
+        expect(slicer.oomArray).toHaveLength(1);
+        expect(slicer.oomArray[0]).toBeInstanceOf(Buffer);
+        expect(slicer.oomArray[0].length).toEqual(1024);
+
+        await test.createSlices();
+        expect(slicer.oomArray).toHaveLength(2);
+    });
+
+    it('should allocate buffers of configured byte size', async () => {
+        const bytes = 2048;
+        const test = await makeSlicerTest({ bytes });
+        const slicer = (test as any).executionContext._slicer as any;
+
+        await test.createSlices();
+
+        expect(slicer.oomArray[0].length).toEqual(bytes);
+    });
+});


### PR DESCRIPTION
This PR adds a slicer that eventually fail with an out of memory (OOM) error. Use the `bytes` config option to set the number of bytes to add to the slicer's internal array. Use `delay` to cause the slicer to wait a set number of milliseconds before finishing the slice. Each slice will add to the array until all memory is consumed and the execution controller OOMs.