### PR TITLE
bundled deps update 2026-05-04

### DIFF
--- a/asset/package.json
+++ b/asset/package.json
@@ -16,11 +16,11 @@
         "test": "pnpm -C ../ test"
     },
     "dependencies": {
-        "@terascope/core-utils": "^2.5.3",
-        "@terascope/data-mate": "~2.6.3",
+        "@terascope/core-utils": "^2.6.0",
+        "@terascope/data-mate": "~2.7.0",
         "@terascope/file-asset-apis": "^2.1.0",
-        "@terascope/job-components": "~2.6.2",
-        "@terascope/teraslice-state-storage": "~2.5.3",
+        "@terascope/job-components": "~2.8.0",
+        "@terascope/teraslice-state-storage": "~2.6.0",
         "@types/express": "~5.0.5",
         "express": "~5.2.1",
         "tslib": "~2.8.1",

--- a/package.json
+++ b/package.json
@@ -27,12 +27,12 @@
         "test:watch": "ts-scripts test --watch asset --"
     },
     "devDependencies": {
-        "@terascope/core-utils": "^2.5.3",
+        "@terascope/core-utils": "^2.6.0",
         "@terascope/eslint-config": "~1.1.31",
         "@terascope/file-asset-apis": "^2.1.0",
-        "@terascope/job-components": "~2.6.2",
-        "@terascope/scripts": "~2.7.0",
-        "@terascope/types": "^2.5.0",
+        "@terascope/job-components": "~2.8.0",
+        "@terascope/scripts": "~2.9.1",
+        "@terascope/types": "^2.6.0",
         "@types/express": "~5.0.5",
         "@types/fs-extra": "~11.0.4",
         "@types/jest": "~30.0.0",
@@ -47,7 +47,7 @@
         "jest-extended": "~7.0.0",
         "node-notifier": "~10.0.1",
         "semver": "~7.7.3",
-        "teraslice-test-harness": "~2.7.2",
+        "teraslice-test-harness": "~2.9.0",
         "ts-jest": "~29.4.9",
         "tslib": "~2.8.1",
         "typescript": "~5.9.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     devDependencies:
       '@terascope/core-utils':
-        specifier: ^2.5.3
-        version: 2.5.3
+        specifier: ^2.6.0
+        version: 2.6.0
       '@terascope/eslint-config':
         specifier: ~1.1.31
         version: 1.1.31(jest@30.3.0(@types/node@25.6.0)(node-notifier@10.0.1))
@@ -18,14 +18,14 @@ importers:
         specifier: ^2.1.0
         version: 2.1.0
       '@terascope/job-components':
-        specifier: ~2.6.2
-        version: 2.6.2
+        specifier: ~2.8.0
+        version: 2.8.0
       '@terascope/scripts':
-        specifier: ~2.7.0
-        version: 2.7.0(typescript@5.9.3)
+        specifier: ~2.9.1
+        version: 2.9.1(typescript@5.9.3)
       '@terascope/types':
-        specifier: ^2.5.0
-        version: 2.5.0
+        specifier: ^2.6.0
+        version: 2.6.0
       '@types/express':
         specifier: ~5.0.5
         version: 5.0.6
@@ -69,8 +69,8 @@ importers:
         specifier: ~7.7.3
         version: 7.7.4
       teraslice-test-harness:
-        specifier: ~2.7.2
-        version: 2.7.2
+        specifier: ~2.9.0
+        version: 2.9.0
       ts-jest:
         specifier: ~29.4.9
         version: 29.4.9(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.6.0)(node-notifier@10.0.1))(typescript@5.9.3)
@@ -84,20 +84,20 @@ importers:
   asset:
     dependencies:
       '@terascope/core-utils':
-        specifier: ^2.5.3
-        version: 2.5.3
+        specifier: ^2.6.0
+        version: 2.6.0
       '@terascope/data-mate':
-        specifier: ~2.6.3
-        version: 2.6.3
+        specifier: ~2.7.0
+        version: 2.7.0
       '@terascope/file-asset-apis':
         specifier: ^2.1.0
         version: 2.1.0
       '@terascope/job-components':
-        specifier: ~2.6.2
-        version: 2.6.2
+        specifier: ~2.8.0
+        version: 2.8.0
       '@terascope/teraslice-state-storage':
-        specifier: ~2.5.3
-        version: 2.5.3
+        specifier: ~2.6.0
+        version: 2.6.0
       '@types/express':
         specifier: ~5.0.5
         version: 5.0.6
@@ -951,20 +951,20 @@ packages:
     resolution: {integrity: sha512-aYhGu9byYnyfvhhnYX7TmoDpZWLe0Ry6yDA7ppRpgeByhJggBc55gEuevUT74WpPsC2E4cR6UEK+ajUoaGZ6qg==}
     engines: {node: '>=22.0.0', pnpm: '>=10.25.0'}
 
-  '@terascope/core-utils@2.5.3':
-    resolution: {integrity: sha512-/mO+cB6YxTq5MXNQfy3AWKAVNRBvaSIYcqH6Bpj6acmXp818W0isoEma+nVBt+EMuT7BNFkcspWjIFs+QuvdmQ==}
+  '@terascope/core-utils@2.6.0':
+    resolution: {integrity: sha512-inC42sOCZZRRgVVB7iLxqOF7f4+0HwiyU0kEGuqTY7J3+Bh+26xlOnEEMstbAxTsaMfN70GvXHbEUA9JSc7LbA==}
     engines: {node: '>=22.0.0', pnpm: '>=10.25.0'}
 
-  '@terascope/data-mate@2.6.3':
-    resolution: {integrity: sha512-EwJaVD8EjhWHOgJRICl0npyw3qzrSlOBQ/pnsRiAp7h4KOoSPlv0Kjwm1zK25SRCW6erl/Gt7J2sob+Cc7+yWQ==}
+  '@terascope/data-mate@2.7.0':
+    resolution: {integrity: sha512-AWOWH1jsy/NyD6mRg7usxNmKBoBqQ/Dr3ksyfXoy2EUK4zePtoV911DqP4xd4m/2dm5PIkfOnQX10Q7Wh9dkDQ==}
     engines: {node: '>=22.0.0', pnpm: '>=10.25.0'}
 
-  '@terascope/data-types@2.5.3':
-    resolution: {integrity: sha512-Vw8ahncYZws6K91YLKmi4b/uSbY9CK+YLuN7GE2a7K5TyE1J15l/EhiLD8yqS46pRcGc3EKONXrMGR0pLju5yQ==}
+  '@terascope/data-types@2.6.0':
+    resolution: {integrity: sha512-vGsSVBz4ygP5O1w7Q5F+HlQBZWxGyvUiGyjAbhPVHga6pI+CycQ9Pq0w1kzFv7gT2oQhGM4i+Yc3qT60OXNx3Q==}
     engines: {node: '>=22.0.0', pnpm: '>=10.25.0'}
 
-  '@terascope/elasticsearch-api@5.5.3':
-    resolution: {integrity: sha512-5OsqSi2zxTfLJOJwrqS8ecpooOgxBPMQqpHYfg+lIFHUSwQw+AK7SwSFiy2dzIZFRoD5FMFK6mvX79HoYnYSKA==}
+  '@terascope/elasticsearch-api@5.6.0':
+    resolution: {integrity: sha512-a+RzOm5aJA86Z9jkQFsZP1mWUnNrz24ATwZ4lEafGXMzMm/+U5SMVoltLY4myzV3P7uKeDVdym1jQlqZxGjhlA==}
     engines: {node: '>=22.0.0', pnpm: '>=10.25.0'}
 
   '@terascope/eslint-config@1.1.31':
@@ -980,20 +980,20 @@ packages:
     resolution: {integrity: sha512-RrJbm9WWLe1HIrC77JWBViuIvyQUGpPBaxsqsZI8FyCLkNbKr/7E21IuO1AnIYuLldzK/BXQ8CU9vLqKKLbbaQ==}
     engines: {node: '>=22.21.1', pnpm: '>=10.25.0'}
 
-  '@terascope/geo-utils@2.5.3':
-    resolution: {integrity: sha512-ymU5kM5cnwR6Z9xcJP04dvZSQBa8sjG0fJGGrtsn74jszdoZ7cMxyqXKWZudmhF7piCr2b+7YOiwQ81tV5V+2g==}
+  '@terascope/geo-utils@2.6.0':
+    resolution: {integrity: sha512-3XqsYLKj02YRJMwDUWy4imXsFwzEtB8M2Or0rPfCexUfHZDdZA0ejjKEfRcP/Luq9M3BRCODPOWbyAkf/CSgFQ==}
     engines: {node: '>=22.0.0', pnpm: '>=10.25.0'}
 
-  '@terascope/ip-utils@2.6.3':
-    resolution: {integrity: sha512-A6dKZ9C+HbLWpgyGqkUJpfSuPXfgeBPE+lmJlGyfJdvTXV/g+EcaafvVn214p2sMX7zzUGx8uVgH/M+/vzCEDg==}
+  '@terascope/ip-utils@2.7.0':
+    resolution: {integrity: sha512-28gTwm63iUiUmI2VZ4QID1XCe7+yc7lxe73EB15oQFT4Ex/4jyZPBkzI87Ne6bgZe4SMW3AhZjyeCwjT14A3cw==}
     engines: {node: '>=22.0.0', pnpm: '>=10.25.0'}
 
-  '@terascope/job-components@2.6.2':
-    resolution: {integrity: sha512-alQfEvE6vSPLPKX5zlnFXR3TwBqfPAvm7yWM7TiBm9t77Ql90GK/v9h2jMHdy19LHoWGb2Zg2j0YzZd+Bpfn6g==}
+  '@terascope/job-components@2.8.0':
+    resolution: {integrity: sha512-sCmox899XeW4O1NRQuEDzswUdLO5htJYx6g7tG/vgzNuefnhjU/6FWaFeNxMXt14Q3Q41EH9t7GDSDnFmWDSbQ==}
     engines: {node: '>=22.0.0', pnpm: '>=10.25.0'}
 
-  '@terascope/scripts@2.7.0':
-    resolution: {integrity: sha512-PV4ZmJ2HOTmu+tMex1CmXwemiCII/xTKNXdBjfnuw53T0PSzJahcPAvVA2KpwrMAYBdOQxjGui7pa3ULvb3d9Q==}
+  '@terascope/scripts@2.9.1':
+    resolution: {integrity: sha512-7+a500z40hAVJ5joq17YPHujSbH9udi3QaxCrc4QVtZE/axn9s4Q8KbDD9k1vrmbJti1nJ2OijfZr0NZUZupaQ==}
     engines: {node: '>=22.0.0', pnpm: '>=10.25.0'}
     hasBin: true
     peerDependencies:
@@ -1002,16 +1002,16 @@ packages:
       typescript:
         optional: true
 
-  '@terascope/teraslice-state-storage@2.5.3':
-    resolution: {integrity: sha512-NxptHJoYrPkDFgEID0AjSAD1vyPCBtLU7zioc0+4Xuuv5cLd58nfd4qkky+iI2WK4GlBqYISM8CpQujamB53KQ==}
+  '@terascope/teraslice-state-storage@2.6.0':
+    resolution: {integrity: sha512-kWmBb4r+utvKL4fb7Qe1OGGhkmF3ZU8vs6zeGxGXIU6K37SqK4CwqH7IJJI9LCOpLd5xheCUcmGYCkebbBPI5A==}
     engines: {node: '>=22.0.0', pnpm: '>=10.25.0'}
 
   '@terascope/types@2.3.2':
     resolution: {integrity: sha512-ggUR/sMC8I3fzasv9VmA+MiGmaUPmeYHhwrZ4vCvNSlxaoy/rZm2R95B4X8nnLKqKZkQq9OQRVrOb05/UKbKjw==}
     engines: {node: '>=22.0.0', pnpm: '>=10.25.0'}
 
-  '@terascope/types@2.5.0':
-    resolution: {integrity: sha512-CAuF9HR3fA2u5MMih6HZJ9m03ruJZbwkUkcZPajyHCeU7NaZWOQUI0zJjqydl1jt3R6IgydH8g2QaMhVJEZObg==}
+  '@terascope/types@2.6.0':
+    resolution: {integrity: sha512-QyHAugBschN4E529meaUlGPmUkB3Nl2/0w9f+2M73evpnk5jFYuzXS+6U653zLHG/ltFCjI+OsPRQVWBaenfYQ==}
     engines: {node: '>=22.0.0', pnpm: '>=10.25.0'}
 
   '@turf/bbox-polygon@7.3.5':
@@ -1550,8 +1550,8 @@ packages:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
 
-  b4a@1.8.0:
-    resolution: {integrity: sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==}
+  b4a@1.8.1:
+    resolution: {integrity: sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==}
     peerDependencies:
       react-native-b4a: '*'
     peerDependenciesMeta:
@@ -1607,15 +1607,15 @@ packages:
       bare-buffer:
         optional: true
 
-  bare-os@3.9.0:
-    resolution: {integrity: sha512-JTjuZyNIDpw+GytMO4a6TK1VXdVKKJr6DRxEHasyuYyShV2deuiHJK/ahGZlebc+SG0/wJCB9XK8gprBGDFi/Q==}
+  bare-os@3.9.1:
+    resolution: {integrity: sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==}
     engines: {bare: '>=1.14.0'}
 
   bare-path@3.0.0:
     resolution: {integrity: sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==}
 
-  bare-stream@2.13.0:
-    resolution: {integrity: sha512-3zAJRZMDFGjdn+RVnNpF9kuELw+0Fl3lpndM4NcEOhb9zwtSo/deETfuIwMSE5BXanA0FrN1qVjffGwAg2Y7EA==}
+  bare-stream@2.13.1:
+    resolution: {integrity: sha512-Vp0cnjYyrEC4whYTymQ+YZi6pBpfiICZO3cfRG8sy67ZNWe951urv1x4eW1BKNngw3U+3fPYb5JQvHbCtxH7Ow==}
     peerDependencies:
       bare-abort-controller: '*'
       bare-buffer: '*'
@@ -2635,12 +2635,12 @@ packages:
     resolution: {integrity: sha512-xgs2NH9AE66ucSq4cNG1nhSFghr5l6tdL15Pk+jl46bmmBapgoaY/AacXyaDznAqmGL99TiLSQgO/XazFSKYeQ==}
     engines: {node: '>=0.10.0'}
 
-  ip-address@10.1.0:
-    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
     engines: {node: '>= 12'}
 
-  ip-bigint@8.3.5:
-    resolution: {integrity: sha512-7OQKwX+HsTdIjysq05JWw/gchCMkSY3RW9blZUKY9xxr5DshwwOay9cko8ZgSC2nVUoOPZlSI51wLoxoscJV6w==}
+  ip-bigint@8.3.6:
+    resolution: {integrity: sha512-IRan4ty1RP2aI0MDQtfEs6gGtjDLb/4808xm21BK+ytLquz8FLiWQlepONVcQycjku3HPPEPPUcg9Om8hdOzJQ==}
     engines: {node: '>=18'}
 
   ip@2.0.1:
@@ -3261,6 +3261,9 @@ packages:
   mnemonist@0.40.3:
     resolution: {integrity: sha512-Vjyr90sJ23CKKH/qPAgUKicw/v6pRoamxIEDFOF8uSgFME7DqPRpHgRTejWVjkdGg5dXj0/NyxZHZ9bcjH+2uQ==}
 
+  mnemonist@0.40.4:
+    resolution: {integrity: sha512-ZAv+KNavneRVzu4tUeOgzkScI3W5BGwZ3rkxIpKtzzVgfTtWQFN1CgX0U72cyvyh3iTuHL3SiSmrQxTlryEIcw==}
+
   moment@2.30.1:
     resolution: {integrity: sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==}
 
@@ -3279,8 +3282,8 @@ packages:
   nan@2.26.2:
     resolution: {integrity: sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==}
 
-  nanoid@5.1.9:
-    resolution: {integrity: sha512-ZUvP7KeBLe3OZ1ypw6dI/TzYJuvHP77IM4Ry73waSQTLn8/g8rpdjfyVAh7t1/+FjBtG4lCP42MEbDxOsRpBMw==}
+  nanoid@5.1.11:
+    resolution: {integrity: sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg==}
     engines: {node: ^18 || >=20}
     hasBin: true
 
@@ -3397,8 +3400,8 @@ packages:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
 
-  openid-client@6.8.3:
-    resolution: {integrity: sha512-AoY/NaN9esS3+xvHInFSK0g3skSfeE0uqQAKRj4rB6/GsBIvzwTUaYo9+HcqpKIaP0dP85p5W07hayKgS4GAeA==}
+  openid-client@6.8.4:
+    resolution: {integrity: sha512-QSw0BA08piujetEwfZsHoTrDpMEha7GDZDicQqVwX4u0ChCjefvjDB++TZ8BTg76UpwhzIQgdvvfgfl3HpCSAw==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -3883,8 +3886,8 @@ packages:
     resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
     engines: {node: '>= 14'}
 
-  socks@2.8.7:
-    resolution: {integrity: sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==}
+  socks@2.8.8:
+    resolution: {integrity: sha512-NlGELfPrgX2f1TAAcz0WawlLn+0r3FyhhCRpFFK2CemXenPYvzMWWZINv3eDNo9ucdwme7oCHRY0Jnbs4aIkog==}
     engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
 
   sort-object-keys@2.1.0:
@@ -4052,8 +4055,8 @@ packages:
     resolution: {integrity: sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==}
     engines: {node: '>= 0.8.0'}
 
-  tar-stream@3.1.8:
-    resolution: {integrity: sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==}
+  tar-stream@3.2.0:
+    resolution: {integrity: sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==}
 
   tdigest@0.1.2:
     resolution: {integrity: sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==}
@@ -4061,8 +4064,8 @@ packages:
   teex@1.0.1:
     resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
 
-  teraslice-test-harness@2.7.2:
-    resolution: {integrity: sha512-dYch1lR+T6v0csrHEDzFb7lEA6BpQNqjszFd2Im3L3W3NeUdlptXd+Fri+wD0b95PH+9RKq3OGmsEQFM5liqlA==}
+  teraslice-test-harness@2.9.0:
+    resolution: {integrity: sha512-dJVl+FlC1p1oQzW0I7UhCt2FPrAsE6v7ZcfCiA0jP5aiMj9BqDq1ZSk55aMaoUbWAVbpXS++4yX9f8DwH6Cg3A==}
     engines: {node: '>=22.0.0', pnpm: '>=10.25.0'}
 
   test-exclude@6.0.0:
@@ -4365,8 +4368,8 @@ packages:
       utf-8-validate:
         optional: true
 
-  xlucene-parser@2.6.3:
-    resolution: {integrity: sha512-6ulWtkKuCQ9Nba5Gboj2mfPhw/fbkucwSMsbVktVi2ZHlD3zpnc8w34W6wGDuzOKDgIcSd30Prr7Ynbckram1A==}
+  xlucene-parser@2.7.0:
+    resolution: {integrity: sha512-SXWkrCtRDujVzJINK1s+ZlEcVeAwR8iOpviurIwnw2AhH0ORL0omQFaTl691g2vOxbnqlf6p/btKh2+YaIm1Ww==}
     engines: {node: '>=22.0.0', pnpm: '>=10.25.0'}
 
   xtend@4.0.2:
@@ -4383,8 +4386,8 @@ packages:
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
-  yaml@2.8.3:
-    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
+  yaml@2.8.4:
+    resolution: {integrity: sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==}
     engines: {node: '>= 14.6'}
     hasBin: true
 
@@ -5390,7 +5393,7 @@ snapshots:
       js-yaml: 4.1.1
       jsonpath-plus: 10.4.0
       node-fetch: 2.7.0
-      openid-client: 6.8.3
+      openid-client: 6.8.4
       rfc4648: 1.5.4
       socks-proxy-agent: 8.0.5
       stream-buffers: 3.0.3
@@ -5850,9 +5853,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@terascope/core-utils@2.5.3':
+  '@terascope/core-utils@2.6.0':
     dependencies:
-      '@terascope/types': 2.5.0
+      '@terascope/types': 2.6.0
       awesome-phonenumber: 7.8.0
       bunyan: 1.8.15
       date-fns: 4.1.0
@@ -5872,39 +5875,39 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@terascope/data-mate@2.6.3':
+  '@terascope/data-mate@2.7.0':
     dependencies:
-      '@terascope/core-utils': 2.5.3
-      '@terascope/data-types': 2.5.3
-      '@terascope/geo-utils': 2.5.3
-      '@terascope/ip-utils': 2.6.3
-      '@terascope/types': 2.5.0
+      '@terascope/core-utils': 2.6.0
+      '@terascope/data-types': 2.6.0
+      '@terascope/geo-utils': 2.6.0
+      '@terascope/ip-utils': 2.7.0
+      '@terascope/types': 2.6.0
       '@types/validator': 13.15.10
       awesome-phonenumber: 7.8.0
       big-json: 3.2.0
       date-fns: 4.1.0
-      ip-bigint: 8.3.5
+      ip-bigint: 8.3.6
       jexl: 2.3.0
-      mnemonist: 0.40.3
+      mnemonist: 0.40.4
       uuid: 14.0.0
       valid-url: 1.0.9
       validator: 13.15.35
-      xlucene-parser: 2.6.3
+      xlucene-parser: 2.7.0
     transitivePeerDependencies:
       - supports-color
 
-  '@terascope/data-types@2.5.3':
+  '@terascope/data-types@2.6.0':
     dependencies:
-      '@terascope/core-utils': 2.5.3
-      '@terascope/types': 2.5.0
+      '@terascope/core-utils': 2.6.0
+      '@terascope/types': 2.6.0
       graphql: 16.12.0
     transitivePeerDependencies:
       - supports-color
 
-  '@terascope/elasticsearch-api@5.5.3':
+  '@terascope/elasticsearch-api@5.6.0':
     dependencies:
-      '@terascope/core-utils': 2.5.3
-      '@terascope/types': 2.5.0
+      '@terascope/core-utils': 2.6.0
+      '@terascope/types': 2.6.0
       setimmediate: 1.0.5
     transitivePeerDependencies:
       - supports-color
@@ -5959,10 +5962,10 @@ snapshots:
       - aws-crt
       - supports-color
 
-  '@terascope/geo-utils@2.5.3':
+  '@terascope/geo-utils@2.6.0':
     dependencies:
-      '@terascope/core-utils': 2.5.3
-      '@terascope/types': 2.5.0
+      '@terascope/core-utils': 2.6.0
+      '@terascope/types': 2.6.0
       '@turf/bbox': 7.3.5
       '@turf/bbox-polygon': 7.3.5
       '@turf/boolean-contains': 7.3.5
@@ -5980,17 +5983,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@terascope/ip-utils@2.6.3':
+  '@terascope/ip-utils@2.7.0':
     dependencies:
-      '@terascope/core-utils': 2.5.3
-      '@terascope/types': 2.5.0
+      '@terascope/core-utils': 2.6.0
+      '@terascope/types': 2.6.0
     transitivePeerDependencies:
       - supports-color
 
-  '@terascope/job-components@2.6.2':
+  '@terascope/job-components@2.8.0':
     dependencies:
-      '@terascope/core-utils': 2.5.3
-      '@terascope/types': 2.5.0
+      '@terascope/core-utils': 2.6.0
+      '@terascope/types': 2.6.0
       import-meta-resolve: 4.2.0
       prom-client: 15.1.3
       semver: 7.7.4
@@ -5998,10 +6001,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@terascope/scripts@2.7.0(typescript@5.9.3)':
+  '@terascope/scripts@2.9.1(typescript@5.9.3)':
     dependencies:
       '@kubernetes/client-node': 1.4.0
-      '@terascope/core-utils': 2.5.3
+      '@terascope/core-utils': 2.6.0
       execa: 9.6.1
       fs-extra: 11.3.4
       globby: 16.2.0
@@ -6010,9 +6013,9 @@ snapshots:
       js-yaml: 4.1.1
       kafkajs: 2.2.4
       micromatch: 4.0.8
-      mnemonist: 0.40.3
+      mnemonist: 0.40.4
       ms: 2.1.3
-      nanoid: 5.1.9
+      nanoid: 5.1.11
       package-json: 10.0.1
       package-up: 5.0.0
       semver: 7.7.4
@@ -6021,7 +6024,7 @@ snapshots:
       toposort: 2.0.2
       typedoc: 0.28.19(typescript@5.9.3)
       typedoc-plugin-markdown: 4.11.0(typedoc@0.28.19(typescript@5.9.3))
-      yaml: 2.8.3
+      yaml: 2.8.4
       yargs: 18.0.0
     optionalDependencies:
       typescript: 5.9.3
@@ -6034,11 +6037,11 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@terascope/teraslice-state-storage@2.5.3':
+  '@terascope/teraslice-state-storage@2.6.0':
     dependencies:
-      '@terascope/core-utils': 2.5.3
-      '@terascope/elasticsearch-api': 5.5.3
-      '@terascope/types': 2.5.0
+      '@terascope/core-utils': 2.6.0
+      '@terascope/elasticsearch-api': 5.6.0
+      '@terascope/types': 2.6.0
     transitivePeerDependencies:
       - supports-color
 
@@ -6046,7 +6049,7 @@ snapshots:
     dependencies:
       prom-client: 15.1.3
 
-  '@terascope/types@2.5.0':
+  '@terascope/types@2.6.0':
     dependencies:
       prom-client: 15.1.3
 
@@ -6748,7 +6751,7 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
-  b4a@1.8.0: {}
+  b4a@1.8.1: {}
 
   babel-jest@30.3.0(@babel/core@7.29.0):
     dependencies:
@@ -6812,20 +6815,20 @@ snapshots:
     dependencies:
       bare-events: 2.8.2
       bare-path: 3.0.0
-      bare-stream: 2.13.0(bare-events@2.8.2)
+      bare-stream: 2.13.1(bare-events@2.8.2)
       bare-url: 2.4.2
       fast-fifo: 1.3.2
     transitivePeerDependencies:
       - bare-abort-controller
       - react-native-b4a
 
-  bare-os@3.9.0: {}
+  bare-os@3.9.1: {}
 
   bare-path@3.0.0:
     dependencies:
-      bare-os: 3.9.0
+      bare-os: 3.9.1
 
-  bare-stream@2.13.0(bare-events@2.8.2):
+  bare-stream@2.13.1(bare-events@2.8.2):
     dependencies:
       streamx: 2.25.0
       teex: 1.0.1
@@ -8024,9 +8027,9 @@ snapshots:
 
   invert-kv@1.0.0: {}
 
-  ip-address@10.1.0: {}
+  ip-address@10.2.0: {}
 
-  ip-bigint@8.3.5: {}
+  ip-bigint@8.3.6: {}
 
   ip@2.0.1: {}
 
@@ -8789,6 +8792,10 @@ snapshots:
     dependencies:
       obliterator: 2.0.5
 
+  mnemonist@0.40.4:
+    dependencies:
+      obliterator: 2.0.5
+
   moment@2.30.1: {}
 
   ms@2.1.3: {}
@@ -8807,7 +8814,7 @@ snapshots:
   nan@2.26.2:
     optional: true
 
-  nanoid@5.1.9: {}
+  nanoid@5.1.11: {}
 
   napi-postinstall@0.3.4: {}
 
@@ -8919,7 +8926,7 @@ snapshots:
     dependencies:
       mimic-fn: 2.1.0
 
-  openid-client@6.8.3:
+  openid-client@6.8.4:
     dependencies:
       jose: 6.2.3
       oauth4webapi: 3.8.6
@@ -9425,13 +9432,13 @@ snapshots:
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3
-      socks: 2.8.7
+      socks: 2.8.8
     transitivePeerDependencies:
       - supports-color
 
-  socks@2.8.7:
+  socks@2.8.8:
     dependencies:
-      ip-address: 10.1.0
+      ip-address: 10.2.0
       smart-buffer: 4.2.0
 
   sort-object-keys@2.1.0: {}
@@ -9623,7 +9630,7 @@ snapshots:
   tar-fs@3.1.2:
     dependencies:
       pump: 3.0.4
-      tar-stream: 3.1.8
+      tar-stream: 3.2.0
     optionalDependencies:
       bare-fs: 4.7.1
       bare-path: 3.0.0
@@ -9642,9 +9649,9 @@ snapshots:
       to-buffer: 1.2.2
       xtend: 4.0.2
 
-  tar-stream@3.1.8:
+  tar-stream@3.2.0:
     dependencies:
-      b4a: 1.8.0
+      b4a: 1.8.1
       bare-fs: 4.7.1
       fast-fifo: 1.3.2
       streamx: 2.25.0
@@ -9664,10 +9671,10 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
-  teraslice-test-harness@2.7.2:
+  teraslice-test-harness@2.9.0:
     dependencies:
       '@terascope/fetch-github-release': 2.3.1
-      '@terascope/job-components': 2.6.2
+      '@terascope/job-components': 2.8.0
       decompress: 4.2.1
       fs-extra: 11.3.4
     transitivePeerDependencies:
@@ -9681,7 +9688,7 @@ snapshots:
 
   text-decoder@1.2.7:
     dependencies:
-      b4a: 1.8.0
+      b4a: 1.8.1
     transitivePeerDependencies:
       - react-native-b4a
 
@@ -9814,7 +9821,7 @@ snapshots:
       markdown-it: 14.1.1
       minimatch: 10.2.5
       typescript: 5.9.3
-      yaml: 2.8.3
+      yaml: 2.8.4
 
   typescript-eslint@8.54.0(eslint@9.39.4)(typescript@5.9.3):
     dependencies:
@@ -10004,12 +10011,12 @@ snapshots:
 
   ws@8.20.0: {}
 
-  xlucene-parser@2.6.3:
+  xlucene-parser@2.7.0:
     dependencies:
-      '@terascope/core-utils': 2.5.3
-      '@terascope/geo-utils': 2.5.3
-      '@terascope/ip-utils': 2.6.3
-      '@terascope/types': 2.5.0
+      '@terascope/core-utils': 2.6.0
+      '@terascope/geo-utils': 2.6.0
+      '@terascope/ip-utils': 2.7.0
+      '@terascope/types': 2.6.0
       peggy: 5.1.0
     transitivePeerDependencies:
       - supports-color
@@ -10022,7 +10029,7 @@ snapshots:
 
   yallist@3.1.1: {}
 
-  yaml@2.8.3: {}
+  yaml@2.8.4: {}
 
   yargs-parser@21.1.1: {}
 


### PR DESCRIPTION
This PR updates the following dependencies:

## Chaos Assets

- @terascope/core-utils: `v2.6.0`
- @terascope/data-mate: `v2.7.0`
- @terascope/job-components: `v2.8.0`
- @terascope/teraslice-state-storage: `v2.6.0`

## Workspace

- @terascope/core-utils: `v2.6.0`
- @terascope/job-components: `v2.8.0`
- @terascope/scripts: `v2.9.1`
- @terascope/types: `v2.6.0`
- teraslice-test-harness: `v2.9.0`